### PR TITLE
Added support for notifying rabbmiq server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ require 'vendor/deployphp/recipes/recipes/cachetool.php';
 | cachetool | [read](http://github.com/deployphp/recipes/blob/master/docs/cachetool.md) | `require 'vendor/deployphp/recipes/recipes/cachetool.php';`
 | newrelic  | [read](http://github.com/deployphp/recipes/blob/master/docs/newrelic.md)  | `require 'vendor/deployphp/recipes/recipes/newrelic.php';`
 | slack     | [read](http://github.com/deployphp/recipes/blob/master/docs/slack.md)     | `require 'vendor/deployphp/recipes/recipes/slack.php';`
-
+| rabbit    | [read](http://github.com/deployphp/recipes/blob/master/docs/rabbit.md)    | `require 'vendor/deployphp/recipes/recipes/rabbit.php';`
 
 ## Contributing a recipe
 

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,7 @@
         "source": "https://github.com/deployphp/recipes"
     },
     "minimum-stability": "stable",
-    "require": {
-        "videlalvaro/php-amqplib": "v2.1.0"
-    },
+    "require": { },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
         "source": "https://github.com/deployphp/recipes"
     },
     "minimum-stability": "stable",
-    "require": {},
+    "require": {
+        "videlalvaro/php-amqplib": "v2.1.0"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"

--- a/docs/rabbit.md
+++ b/docs/rabbit.md
@@ -1,0 +1,50 @@
+# Rabbit recipe
+
+### Installing
+
+```php
+// deploy.php
+
+require 'vendor/deployphp/recipes/recipes/rabbit.php';
+```
+
+### Configuration options
+
+- **rabbit** *(required)*: accepts an *array* with the connection information to [rabbitmq](http://www.rabbitmq.com) server token and team name.
+
+
+You can provide also other configuration options:
+
+ - *host* - default is localhost
+ - *port* - default is 5672
+ - *username* - default is *guest*
+ - *password* - default is *guest*
+ - *channel* - no default value, need to be specified via config
+ - *message* - default is **Deployment to '{$host}' on *{$prod}* was successful\n($releasePath)**
+
+
+```php
+// deploy.php
+
+set('rabbit', [
+    'host' => 'localhost',
+    'port' => '5672',
+    'username' => 'guest',
+    'password' => 'guest',
+    'channel' => 'notify-channel',
+]);
+```
+
+### Tasks
+
+- `deploy:rabbit` send message to rabbit
+
+### Suggested Usage
+
+Since you should only notify RabbitMQ channel of a successfull deployment, the `deploy:rabbit` task should be executed right at the end.
+
+```php
+// deploy.php
+
+before('deploy:end', 'deploy:rabbit');
+```

--- a/recipes/rabbit.php
+++ b/recipes/rabbit.php
@@ -5,6 +5,10 @@
  * file that was distributed with this source code.
  */
 
+use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+
+
 /**
  * Notify Rabbit of successful deployment
  */
@@ -37,10 +41,10 @@ task('deploy:rabbit', function () {
         throw new \RuntimeException("<comment>Please configure rabbit config:</comment> <info>set('rabbit', array('channel' => 'channel', 'host' => 'host', 'port' => 'port', 'username' => 'username', 'password' => 'password'));</info>");
     }
 
-    $connection = new \PhpAmqpLib\Connection\AMQPConnection($config['host'], $config['port'], $config['username'], $config['password']);
+    $connection = new AMQPConnection($config['host'], $config['port'], $config['username'], $config['password']);
     $channel = $connection->channel();
 
-    $msg = new \PhpAmqpLib\Message\AMQPMessage($config['message']);
+    $msg = new AMQPMessage($config['message']);
     $channel->basic_publish($msg, '', $config['channel']);
 
     $channel->close();

--- a/recipes/rabbit.php
+++ b/recipes/rabbit.php
@@ -13,7 +13,7 @@ use PhpAmqpLib\Message\AMQPMessage;
  */
 task('deploy:rabbit', function () {
     
-    if (!class_exists('AMQPConnection')) {
+    if (!class_exists('PhpAmqpLib\Connection\AMQPConnection')) {
         throw new \RuntimeException("<comment>Please install php package</comment> <info>videlalvaro/php-amqplib</info> <comment>to use rabbitmq</comment>");
     }
 

--- a/recipes/rabbit.php
+++ b/recipes/rabbit.php
@@ -8,11 +8,15 @@
 use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
-
 /**
  * Notify Rabbit of successful deployment
  */
 task('deploy:rabbit', function () {
+    
+    if (!class_exists('AMQPConnection')) {
+        throw new \RuntimeException("<comment>Please install php package</comment> <info>videlalvaro/php-amqplib</info> <comment>to use rabbitmq</comment>");
+    }
+
     $config = get('rabbit', []);
 
     if (!isset($config['message'])) {

--- a/recipes/rabbit.php
+++ b/recipes/rabbit.php
@@ -1,0 +1,49 @@
+<?php
+/* (c) Tomas Majer <tomasmajer@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Notify Rabbit of successful deployment
+ */
+task('deploy:rabbit', function () {
+    $config = get('rabbit', []);
+
+    if (!isset($config['message'])) {
+        $releasePath = env()->getReleasePath();
+        $host = config()->getHost();
+        $prod = get('env', 'production');
+        $config['message'] = "Deployment to '{$host}' on *{$prod}* was successful\n($releasePath)";
+    }
+
+    $defaultConfig = array(
+        'host' => 'localhost',
+        'port' => 5672,
+        'username' => 'guest',
+        'password' => 'guest',
+    );
+
+    $config = array_merge($defaultConfig, $config);
+
+    if (!is_array($config) ||
+        !isset($config['channel']) ||
+        !isset($config['host']) ||
+        !isset($config['port']) ||
+        !isset($config['username']) ||
+        !isset($config['password']))
+    {
+        throw new \RuntimeException("<comment>Please configure rabbit config:</comment> <info>set('rabbit', array('channel' => 'channel', 'host' => 'host', 'port' => 'port', 'username' => 'username', 'password' => 'password'));</info>");
+    }
+
+    $connection = new \PhpAmqpLib\Connection\AMQPConnection($config['host'], $config['port'], $config['username'], $config['password']);
+    $channel = $connection->channel();
+
+    $msg = new \PhpAmqpLib\Message\AMQPMessage($config['message']);
+    $channel->basic_publish($msg, '', $config['channel']);
+
+    $channel->close();
+    $connection->close();
+
+})->desc('Notifying RabbitMQ channel about deployment');


### PR DESCRIPTION
I need notify rabbitmq on one project after deployment so i created recipe. I need one dependency for this - [videlalvaro/php-amqplib](https://github.com/videlalvaro/php-amqplib) than I am not sure if it is ok. If you would like to keep this library without external dependencies, than reject this pull request.