### PR TITLE
Adds a Rsync recipe, basis for performing repository-related tasks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ require 'vendor/deployphp/recipes/recipes/cachetool.php';
 | ------    | ----                                                                      | -----
 | cachetool | [read](http://github.com/deployphp/recipes/blob/master/docs/cachetool.md) | `require 'vendor/deployphp/recipes/recipes/cachetool.php';`
 | newrelic  | [read](http://github.com/deployphp/recipes/blob/master/docs/newrelic.md)  | `require 'vendor/deployphp/recipes/recipes/newrelic.php';`
-| slack     | [read](http://github.com/deployphp/recipes/blob/master/docs/slack.md)     | `require 'vendor/deployphp/recipes/recipes/slack.php';`
 | rabbit    | [read](http://github.com/deployphp/recipes/blob/master/docs/rabbit.md)    | `require 'vendor/deployphp/recipes/recipes/rabbit.php';`
+| rsync     | [read](http://github.com/deployphp/recipes/blob/master/docs/rsync.md)     | `require 'vendor/deployphp/recipes/recipes/rsync.php';`
+| slack     | [read](http://github.com/deployphp/recipes/blob/master/docs/slack.md)     | `require 'vendor/deployphp/recipes/recipes/slack.php';`
 
 ## Contributing a recipe
 

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -100,7 +100,7 @@ server('local_deploy','local_deploy.host',22)
 ### Tasks
 
 - `rsync` perorms rsync from local `rsync_src` dir to remote `rsync_dest` dir
-- `deploy:rsync_warmup` performs a warmup rsync on remote. Useful only when using `rsync` task instead of `deploy:update_code`
+- `rsync:warmup` performs a warmup rsync on remote. Useful only when using `rsync` task instead of `deploy:update_code`
 
 ### Suggested Usage
 
@@ -108,7 +108,7 @@ server('local_deploy','local_deploy.host',22)
 
 Set `rsync_src` to locally cloned repository and rsync to `rsync_dest`. Then set this task instead of `deploy:update_code` in Your `deploy` task if Your hosting provider does not allow git.
 
-#### `deploy:rsync_warmup` task
+#### `rsync:warmup` task
 
 If Your deploy task looks like:
 

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -22,7 +22,9 @@ require 'vendor/deployphp/recipes/recipes/rsync.php';
 - *flags*: accepts a *string* of flags to set when calling rsync command. Please **avoid** flags that accept params, and use *options* instead.
 - *options*: accepts an *array* of options to set when calling rsync command. **DO NOT** prefix options with `--` as it's automaticly added.
 
-#### Sample default Configuration:
+#### Sample Configuration:
+
+Following is default configuration. By default rsync ignores only git dir and `deploy.php` file.
 
 ```php
 // deploy.php
@@ -42,6 +44,25 @@ set('rsync',[
   'options' => ['delete'],
 ]);
 ```
+
+If You have multiple excludes, You can put them in file and reference that instead. If You use `deploy:rsync_warmup` You could set additional options that could speed-up and/or affect way things are working. For example:
+
+```php
+// deploy.php
+
+set('rsync',[
+  'exclude'=> ['excludes_file'],
+  'exclude-file' => /tmp/localdeploys/excludes_file, //Use absolute path to avoid possible rsync problems
+  'include'=> [],
+  'include-file' => false,
+  'filter'=> [],
+  'filter-file' => false,
+  'filter-perdir' => false,
+  'flags' => 'rzcE', // Recursive, with compress, check based on checksum rather than time/size, preserve Executable flag
+  'options' => ['delete', 'delete-after', 'force'], //Delete after successful trasfer, delete even if deleted dir is not empty
+]);
+```
+
 
 ### Environimental Variables
 

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -21,31 +21,42 @@ require 'vendor/deployphp/recipes/recipes/rsync.php';
 - *filter-perdir*: accepts a *string* containing merge-file filename to be scanned and merger per each directory in rsync list offiles to send
 - *flags*: accepts a *string* of flags to set when calling rsync command. Please **avoid** flags that accept params, and use *options* instead.
 - *options*: accepts an *array* of options to set when calling rsync command. **DO NOT** prefix options with `--` as it's automaticly added.
-- *local_release_dir*: accepts a *string* with dirname where temporary repository cloning should take place before being sent to server
+
+### Environimental Variables
+
+- **rsync_src**: per-environment rsync source. This can be server, stage or whatever-dependent. By default it's set to current directory
+- **rsync_src**: per-environment rsync deestination. This can be server, stage or whatever-dependent. by default it's equivalent to release deploy destination.
+
 
 ```php
 // deploy.php
 
 set('rsync',[
-  'excludes'=> [
+  'exclude'=> [
     '.git',
-    'deployer_release',
+    '*_deployer',
     'releases',
     'deploy.php',
     ],
-  'local_release_dir' => '/tmp'
+  'exclude-file' => false,
+  'include'=> [],
+  'include-file' => false,
+  'filter'=> [],
+  'filter-file' => false,
+  'filter-perdir' => false,
+  'flags' => 'rz',
+  'options' => ['delete'],
 ]);
+
+env('rsync_src', __DIR__);
+env('rsync_dest','{{release_path}}');
 ```
 
 ### Tasks
 
-- `deploy:local_release` Creates local release directory
-- `deploy:update_code` overrides standard `deploy:update_code` to update code locally instead of remotelly
-- `deploy:rsync` perorms rsync from local release to remote
+- `rsync` perorms rsync from local `rsync_src` dir to remote `rsync_dest` dir
 
 ### Suggested Usage
 
-This recipe performs all repository-related tasks locally, so the best way to use it, would be to use this instead of `common.php` recipe.
-
-For using composer or other tools, You'd need to override `deploy:vendors` task and plug it in `deploy` chain.
+Set `rsync_src` to locally cloned repository and rsync to `rsync_dest` instead of `deploy:update_code` if Your hosting provider does not allow git.
 

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -55,8 +55,27 @@ env('rsync_dest','{{release_path}}');
 ### Tasks
 
 - `rsync` perorms rsync from local `rsync_src` dir to remote `rsync_dest` dir
+- `deploy:rsync_warmup` performs a warmup rsync on remote. Useful only when using `rsync` task instead of `deploy:update_code`
 
 ### Suggested Usage
 
-Set `rsync_src` to locally cloned repository and rsync to `rsync_dest` instead of `deploy:update_code` if Your hosting provider does not allow git.
+#### `rsync` task
 
+Set `rsync_src` to locally cloned repository and rsync to `rsync_dest`. Then set this task instead of `deploy:update_code` in Your `deploy` task if Your hosting provider does not allow git.
+
+#### `deploy:rsync_warmup` task
+
+If Your deploy task looks like:
+
+```php
+task('deploy', [
+    'deploy:prepare',
+    'deploy:release',
+    'rsync',
+    'deploy:vendors',
+    'deploy:symlink',
+    'cleanup',
+])->desc('Deploy your project');
+```
+
+And Your `rsync_dest` is set to `{{release_path}}` then You could add this task to run before `rsync` task or after `deploy:release`, whatever's more convinient.

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -1,0 +1,43 @@
+# Rsync recipe
+
+### Installing
+
+```php
+// deploy.php
+
+require 'vendor/deployphp/recipes/recipes/rsync.php';
+```
+
+### Configuration options
+
+- **rsync_excludes** *(optional)*: accepts a *array* with files/dirs to be excluded from sending to server
+- **rsync_user** *(optional)*: accepts a *string* with username to server
+- **rsync_local_release_dir** *(optional)*: accepts a *string* with dirname where temporary repository cloning should take place before being sent to server
+
+```php
+// deploy.php
+
+set('rsync_excludes', [
+    '.git',
+    'deployer_release',
+    'releases',
+    'deploy.php',
+]);
+
+set('rsync_user', 'server_user');
+
+set('rsync_local_release_dir', '/tmp');
+```
+
+### Tasks
+
+- `deploy:local_release` Creates local release directory
+- `deploy:update_code` overrides standard `deploy:update_code` to update code locally instead of remotelly
+- `deploy:rsync` perorms rsync from local release to remote
+
+### Suggested Usage
+
+This recipe performs all repository-related tasks locally, so the best way to use it, would be to use this instead of `common.php` recipe.
+
+For using composer or other tools, You'd need to override `deploy:vendors` task and plug it in `deploy` chain.
+

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -13,7 +13,6 @@ require 'vendor/deployphp/recipes/recipes/rsync.php';
 - **rsync**: Accepts an array with following rsync options:
 
 - *excludes* *(optional)*: accepts a *array* with files/dirs to be excluded from sending to server
-- *user* *(optional)*: accepts a *string* with username to server
 - *local_release_dir* *(optional)*: accepts a *string* with dirname where temporary repository cloning should take place before being sent to server
 
 ```php
@@ -26,7 +25,6 @@ set('rsync',[
     'releases',
     'deploy.php',
     ],
-  'user'=> false,
   'local_release_dir' => '/tmp'
 ]);
 ```

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -10,10 +10,18 @@ require 'vendor/deployphp/recipes/recipes/rsync.php';
 
 ### Configuration options
 
-- **rsync**: Accepts an array with following rsync options:
+- **rsync**: Accepts an array with following rsync options (all are optional and defaults are ok):
 
-- *excludes* *(optional)*: accepts a *array* with files/dirs to be excluded from sending to server
-- *local_release_dir* *(optional)*: accepts a *string* with dirname where temporary repository cloning should take place before being sent to server
+- *exclude*: accepts an *array* with patterns to be excluded from sending to server
+- *exclude-file*: accepts a *string* containing absolute path to file, which contains exclude patterns
+- *include*: accepts an *array* with patterns to be included in sending to server
+- *include-file*: accepts a *string* containing absolute path to file, which contains include patterns
+- *filter*: accepts an *array* of rsync filter rules
+- *filter-file*: accepts a *string* containing merge-file filename.
+- *filter-perdir*: accepts a *string* containing merge-file filename to be scanned and merger per each directory in rsync list offiles to send
+- *flags*: accepts a *string* of flags to set when calling rsync command. Please **avoid** flags that accept params, and use *options* instead.
+- *options*: accepts an *array* of options to set when calling rsync command. **DO NOT** prefix options with `--` as it's automaticly added.
+- *local_release_dir*: accepts a *string* with dirname where temporary repository cloning should take place before being sent to server
 
 ```php
 // deploy.php

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -10,23 +10,25 @@ require 'vendor/deployphp/recipes/recipes/rsync.php';
 
 ### Configuration options
 
-- **rsync_excludes** *(optional)*: accepts a *array* with files/dirs to be excluded from sending to server
-- **rsync_user** *(optional)*: accepts a *string* with username to server
-- **rsync_local_release_dir** *(optional)*: accepts a *string* with dirname where temporary repository cloning should take place before being sent to server
+- **rsync**: Accepts an array with following rsync options:
+
+- *excludes* *(optional)*: accepts a *array* with files/dirs to be excluded from sending to server
+- *user* *(optional)*: accepts a *string* with username to server
+- *local_release_dir* *(optional)*: accepts a *string* with dirname where temporary repository cloning should take place before being sent to server
 
 ```php
 // deploy.php
 
-set('rsync_excludes', [
+set('rsync',[
+  'excludes'=> [
     '.git',
     'deployer_release',
     'releases',
     'deploy.php',
+    ],
+  'user'=> false,
+  'local_release_dir' => '/tmp'
 ]);
-
-set('rsync_user', 'server_user');
-
-set('rsync_local_release_dir', '/tmp');
 ```
 
 ### Tasks

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -22,11 +22,7 @@ require 'vendor/deployphp/recipes/recipes/rsync.php';
 - *flags*: accepts a *string* of flags to set when calling rsync command. Please **avoid** flags that accept params, and use *options* instead.
 - *options*: accepts an *array* of options to set when calling rsync command. **DO NOT** prefix options with `--` as it's automaticly added.
 
-### Environimental Variables
-
-- **rsync_src**: per-environment rsync source. This can be server, stage or whatever-dependent. By default it's set to current directory
-- **rsync_src**: per-environment rsync deestination. This can be server, stage or whatever-dependent. by default it's equivalent to release deploy destination.
-
+#### Sample default Configuration:
 
 ```php
 // deploy.php
@@ -34,8 +30,6 @@ require 'vendor/deployphp/recipes/recipes/rsync.php';
 set('rsync',[
   'exclude'=> [
     '.git',
-    '*_deployer',
-    'releases',
     'deploy.php',
     ],
   'exclude-file' => false,
@@ -44,12 +38,42 @@ set('rsync',[
   'filter'=> [],
   'filter-file' => false,
   'filter-perdir' => false,
-  'flags' => 'rz',
+  'flags' => 'rz', // Recursive, with compress
   'options' => ['delete'],
 ]);
+```
+
+### Environimental Variables
+
+- **rsync_src**: per-environment rsync source. This can be server, stage or whatever-dependent. By default it's set to current directory
+- **rsync_src**: per-environment rsync deestination. This can be server, stage or whatever-dependent. by default it's equivalent to release deploy destination.
+
+#### Sample configurations:
+
+This is default configuration: 
+
+```php
+// deploy.php 
+
 
 env('rsync_src', __DIR__);
 env('rsync_dest','{{release_path}}');
+```
+
+If You use local deploy recipe You can set src to local release:
+
+```php
+// deploy.php
+
+server('local_deploy','local_deploy.host',22)
+        ->env('deploy_path','/var/www/vhosts/app')
+        ->env('rsync_src', function(){
+          $local_src = env('local_release_path');
+          if(is_callable($local_src)){
+            $local_src = $local_src();
+          }
+          return $local_src;
+        });
 ```
 
 ### Tasks

--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -1,0 +1,88 @@
+<?php
+/* (c) HAKGER[hakger.pl] Hubert Kowalski <h.kowalski@hakger.pl> 
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require 'recipe/common.php';
+
+set('rsync_excludes', [
+    '.git',
+    'deployer_release',
+    'releases',
+    'deploy.php',
+]);
+
+set('rsync_user', 'server_user');
+
+set('rsync_local_release_dir', '/tmp');
+
+env('local_release_path', function () {
+    $dir = get('rsync_local_release_dir');
+    return str_replace("\n", '', runLocally("readlink $dir/deployer_release"));
+});
+
+task('deploy:local_release', function () {
+    $release = date('YmdHis');
+    $dir = get('rsync_local_release_dir');
+    
+    $releasePath = "$dir/releases/$release";
+
+    $i = 0;
+    while (is_dir(env()->parse($releasePath)) && $i < 42) {
+        $releasePath .= '.' . ++$i;
+    }
+
+    runLocally("mkdir -p $releasePath");
+
+    runLocally("cd $dir && if [ -h deployer_release ]; then rm deployer_release; fi");
+
+    runLocally("ln -s $releasePath $dir/deployer_release");
+})->desc('Prepare local release');
+
+task('deploy:update_code', function () {
+    $repository = get('repository');
+    $branch = env('branch');
+    if (input()->hasOption('tag')) {
+        $tag = input()->getOption('tag');
+    }
+
+    $at = '';
+    if (!empty($tag)) {
+        $at = "-b $tag";
+    } else if (!empty($branch)) {
+        $at = "-b $branch";
+    }
+
+    runLocally("git clone $at --depth 1 --recursive -q $repository {{local_release_path}} 2>&1");
+
+})->desc('Updating code locally');
+
+task('deploy:rsync', function(){
+  
+  $server = env('server.host');
+  $user = get('rsync_user');
+  
+  $excludes = get('rsync_excludes');
+  $excludesRsync='';
+  foreach($excludes as $exclude){
+    $excludesRsync.=' --exclude='.escapeshellarg($exclude);
+  }
+  
+  runLocally("rsync -rav -e 'ssh' $excludesRsync {{local_release_path}}/ $user@$server:{{release_path}}/");
+  
+  
+})->desc('Rsync local->remote');
+
+task('deploy', [
+    'deploy:prepare',
+    'deploy:local_release',
+    'deploy:release',
+    'deploy:update_code',
+    'deploy:rsync',
+    'deploy:symlink',
+    'cleanup',
+])->desc('Deploy your project');
+
+after('deploy', 'success');

--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -8,8 +8,6 @@
 set('rsync',[
   'exclude'=> [
     '.git',
-    '*_deployer',
-    'releases',
     'deploy.php',
     ],
   'exclude-file' => false,

--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -7,25 +7,25 @@
 
 require 'recipe/common.php';
 
-set('rsync_excludes', [
+set('rsync',[
+  'excludes'=> [
     '.git',
     'deployer_release',
     'releases',
     'deploy.php',
+    ],
+  'user'=> false,
+  'local_release_dir' => '/tmp'
 ]);
 
-set('rsync_user', 'server_user');
-
-set('rsync_local_release_dir', '/tmp');
-
 env('local_release_path', function () {
-    $dir = get('rsync_local_release_dir');
+    $dir = get('rsync.local_release_dir');
     return str_replace("\n", '', runLocally("readlink $dir/deployer_release"));
 });
 
 task('deploy:local_release', function () {
     $release = date('YmdHis');
-    $dir = get('rsync_local_release_dir');
+    $dir = get('rsync.local_release_dir');
     
     $releasePath = "$dir/releases/$release";
 
@@ -62,15 +62,15 @@ task('deploy:update_code', function () {
 task('deploy:rsync', function(){
   
   $server = env('server.host');
-  $user = get('rsync_user');
+  $user = !get('rsync.user') ? '' : get('rsync.user').'@';
   
-  $excludes = get('rsync_excludes');
+  $excludes = get('rsync.excludes');
   $excludesRsync='';
   foreach($excludes as $exclude){
     $excludesRsync.=' --exclude='.escapeshellarg($exclude);
   }
   
-  runLocally("rsync -rav -e 'ssh' $excludesRsync {{local_release_path}}/ $user@$server:{{release_path}}/");
+  runLocally("rsync -rav -e 'ssh' $excludesRsync {{local_release_path}}/ $user$server:{{release_path}}/");
   
   
 })->desc('Rsync local->remote');

--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -81,7 +81,7 @@ env('rsync_options', function () {
   return $optionsRsync;
 });
 
-task('deploy:rsync_warmup', function(){
+task('rsync:warmup', function(){
   $config = get('rsync');
   
   $releases = env('releases_list');

--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -83,6 +83,21 @@ env('rsync_options', function () {
   return $optionsRsync;
 });
 
+task('deploy:rsync_warmup', function(){
+  $config = get('rsync');
+  
+  $releases = env('releases_list');
+  
+  if (isset($releases[1])) {
+        $source = "{{deploy_path}}/releases/{$releases[1]}";
+        $destination = "{{deploy_path}}/releases/{$releases[0]}";
+
+        run("rsync -{$config['flags']} {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} $source/ $destination/");
+    } else {
+        writeln("<comment>No way to warmup rsync.</comment>");
+    }
+})->desc('Warmup remote Rsync target');
+
 task('rsync', function(){
   
   $config = get('rsync');

--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -8,19 +8,85 @@
 require 'recipe/common.php';
 
 set('rsync',[
-  'excludes'=> [
+  'exclude'=> [
     '.git',
-    'deployer_release',
+    '*_deployer',
     'releases',
     'deploy.php',
     ],
+  'exclude-file' => false,
+  'include'=> [],
+  'include-file' => false,
+  'filter'=> [],
+  'filter-file' => false,
+  'filter-perdir' => false,
+  'flags' => 'rz',
+  'options' => ['delete'],
   'local_release_dir' => '/tmp'
 ]);
 
 env('local_release_path', function () {
     $config = get('rsync');
     $dir = $config['local_release_dir'];
-    return str_replace("\n", '', runLocally("readlink $dir/deployer_release"));
+    return str_replace("\n", '', runLocally("readlink $dir/{{server.host}}_deployer"));
+});
+
+env('rsync_excludes', function () {
+  $config = get('rsync');
+  $excludes = $config['exclude'];
+  $excludeFile = $config['exclude-file'];
+  $excludesRsync='';
+  foreach($excludes as $exclude){
+    $excludesRsync.=' --exclude='.escapeshellarg($exclude);
+  }
+  if(!empty($excludeFile) && file_exists($excludeFile) && is_file($excludeFile) && is_readable($excludeFile)){
+    $excludesRsync .= ' --exclude-from='.escapeshellarg($excludeFile);
+  }
+  
+  return $excludesRsync;
+});
+
+env('rsync_includes', function () {
+  $config = get('rsync');
+  $includes = $config['include'];
+  $includeFile = $config['include-file'];
+  $includesRsync='';
+  foreach($includes as $include){
+    $includesRsync.=' --include='.escapeshellarg($include);
+  }
+  if(!empty($includeFile) && file_exists($includeFile) && is_file($includeFile) && is_readable($includeFile)){
+    $includesRsync .= ' --include-from='.escapeshellarg($includeFile);
+  }
+  
+  return $includesRsync;
+});
+
+env('rsync_filter', function () {
+  $config = get('rsync');
+  $filters = $config['filter'];
+  $filterFile = $config['filter-file'];
+  $filterPerDir = $config['filter-perdir'];
+  $filtersRsync='';
+  foreach($filters as $filter){
+    $filtersRsync.=" --filter='$filter'";
+  }
+  if(!empty($filterFile)){
+    $filtersRsync .= " --filter='merge $filterFile'";
+  }
+  if(!empty($filterPerDir)){
+    $filtersRsync .= " --filter='dir-merge $filterFile'";
+  }
+  return $filtersRsync;
+});
+
+env('rsync_options', function () {
+  $config = get('rsync');
+  $options = $config['options'];
+  $optionsRsync = '';
+  foreach($options as $option){
+    $optionsRsync .= "--$option";
+  }
+  return $optionsRsync;
 });
 
 task('deploy:local_release', function () {
@@ -37,9 +103,9 @@ task('deploy:local_release', function () {
 
     runLocally("mkdir -p $releasePath");
 
-    runLocally("cd $dir && if [ -h deployer_release ]; then rm deployer_release; fi");
+    runLocally("cd $dir && if [ -h {{server.host}}_deployer ]; then rm {{server.host}}_deployer; fi");
 
-    runLocally("ln -s $releasePath $dir/deployer_release");
+    runLocally("ln -s $releasePath $dir/{{server.host}}_deployer");
 })->desc('Prepare local release');
 
 task('deploy:update_code', function () {
@@ -69,13 +135,7 @@ task('deploy:rsync', function(){
   $port = $server->getPort() ? ' -p'.$server->getPort(): '';
   $user = !$server->getUser() ? '' : $server->getUser().'@';
   
-  $excludes = $config['excludes'];
-  $excludesRsync='';
-  foreach($excludes as $exclude){
-    $excludesRsync.=' --exclude='.escapeshellarg($exclude);
-  }
-  
-  runLocally("rsync -ravz -e 'ssh$port' $excludesRsync {{local_release_path}}/ $user$host:{{release_path}}/");
+  runLocally("rsync -{$config['flags']} -e 'ssh$port' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} {{local_release_path}}/ $user$host:{{release_path}}/");
   
   
 })->desc('Rsync local->remote');


### PR DESCRIPTION
# Rsync recipe

### Installing

```php
// deploy.php

require 'vendor/deployphp/recipes/recipes/rsync.php';
```

### Configuration options

- **rsync_excludes** *(optional)*: accepts a *array* with files/dirs to be excluded from sending to server
- **rsync_user** *(optional)*: accepts a *string* with username to server
- **rsync_local_release_dir** *(optional)*: accepts a *string* with dirname where temporary repository cloning should take place before being sent to server

```php
// deploy.php

set('rsync_excludes', [
    '.git',
    'deployer_release',
    'releases',
    'deploy.php',
]);

set('rsync_user', 'server_user');

set('rsync_local_release_dir', '/tmp');
```

### Tasks

- `deploy:local_release` Creates local release directory
- `deploy:update_code` overrides standard `deploy:update_code` to update code locally instead of remotelly
- `deploy:rsync` perorms rsync from local release to remote

### Suggested Usage

This recipe performs all repository-related tasks locally, so the best way to use it, would be to use this instead of `common.php` recipe.

For using composer or other tools, You'd need to override `deploy:vendors` task and plug it in `deploy` chain.

