### PR TITLE
Fix rsync behaviour with callable environment vars

### DIFF
--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -100,12 +100,21 @@ task('rsync', function(){
   
   $config = get('rsync');
   
+  $src = env('rsync_src');
+  while(is_callable($src)){
+    $src = $src();
+  }
+  $dst = env('rsync_dest');
+  while(is_callable($dst)){
+    $dst = $dst();
+  }
+  
   $server = \Deployer\Task\Context::get()->getServer()->getConfiguration();
   $host = $server->getHost();
   $port = $server->getPort() ? ' -p'.$server->getPort(): '';
   $user = !$server->getUser() ? '' : $server->getUser().'@';
   
-  runLocally("rsync -{$config['flags']} -e 'ssh$port' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} {{rsync_src}}/ $user$host:{{rsync_dest}}/");
+  runLocally("rsync -{$config['flags']} -e 'ssh$port' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} '$src' '$user$host:$dst/'");
   
   
 })->desc('Rsync local->remote');


### PR DESCRIPTION
I run into bit of trouble with rsync when depending on server, rsync is weirdly different. Consider this code:
```php
server('production', 'prod.server', 22)
        ->user('Product')
        ->stage('production')
        ->forwardAgent()
        ->env('deploy_path', '/var/www/vhosts/product')
        ->env('rsync_src', function() {
          $local_src = env('local_release_path');
          if (is_callable($local_src)) {
            $local_src = $local_src();
          }
          return $local_src;
        });
server('dev', 'devel.preview', 22)
        ->user('preview')
        ->stage('dev')
        ->forwardAgent()
        ->env('deploy_path', '/var/www/vhosts/preview.host/product')
        ->env('rsync_src', __DIR__)
        ->env('rsync_dest', '{{current}}');
```

Using rsync without this PR, I got error:

> PHP Catchable fatal error:  Object of class Closure could not be converted to string

on rsync task for production (but not for dev).

This PR fixes rsync behaviour to force it to actually run all calables before using env variable as string in command.