### PR TITLE
Feature/add configure recipe

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,0 +1,28 @@
+# Configure recipe
+
+### Installing
+
+```php
+// deploy.php
+
+require 'vendor/deployphp/recipes/recipes/configure.php';
+```
+
+### Configuration options
+
+Make `shared` directory and put configure template files to it. 
+Template file extension is `.tpl` and it is removed on filename of compiled filed.
+> Note: All configure files will be created with the same structure with template files.
+> Eg:
+> `shared/config/app.php.tpl` -> `shared/config/app.php`
+> `shared/server/apache.conf.tpl` -> `shared/server/apache.conf`
+
+### Tasks
+
+- `deploy:configure` compile configure files and upload to servers
+
+### Suggested Usage
+
+Since you should only once time create configure files before deployment, 
+the `deploy:configure` task should be executed right only once time at the first. 
+If environment variable is changed, you can use this task to re-create configure files.

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -10,12 +10,12 @@ require 'vendor/deployphp/recipes/recipes/configure.php';
 
 ### Configuration options
 
-Make `shared` directory and put configure template files to it. 
-Template file extension is `.tpl` and it is removed on filename of compiled filed.
-> Note: All configure files will be created with the same structure with template files.
-> Eg:
-> `shared/config/app.php.tpl` -> `shared/config/app.php`
-> `shared/server/apache.conf.tpl` -> `shared/server/apache.conf`
+Make `shared` directory and put configure template files to it.   
+Template file extension is `.tpl` and it is removed on filename of compiled files.   
+> Note: All configure files will be created with the same structure with template files.   
+> Eg:   
+> `shared/config/app.php.tpl` -> `shared/config/app.php`   
+> `shared/server/apache.conf.tpl` -> `shared/server/apache.conf`   
 
 ### Tasks
 

--- a/recipes/configure.php
+++ b/recipes/configure.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Make shared_dirs and configure files from templates
+ */
+task('deploy:configure', function () {
+
+    /**
+     * Paser value for template compiler
+     * 
+     * @param array $matches
+     * @return string
+     */
+    $paser = function($matches) {
+        if (isset($matches[1])) {
+            $value = env()->get($matches[1]);
+            if (is_null($value) || is_bool($value) || is_array($value)) {
+                $value = var_export($value, true);
+            }
+        } else {
+            $value = $matches[0];
+        }
+
+        return $value;
+    };
+
+    /**
+     * Template compiler
+     *
+     * @param string $contents
+     * @return string
+     */
+    $compiler = function ($contents) use ($paser) {
+        $contents = preg_replace_callback('/\{\{\s*([\w\.]+)\s*\}\}/', $paser, $contents);
+        
+        return $contents;
+    };
+
+    $finder   = new \Symfony\Component\Finder\Finder();
+    $iterator = $finder
+        ->files()
+        ->name('*.tpl')
+        ->in(__DIR__ . '/shared');
+
+    $tmpDir = sys_get_temp_dir();
+
+    /* @var $file \Symfony\Component\Finder\SplFileInfo */
+    foreach ($iterator as $file) {
+        $success = false;
+        // Make tmp file
+        $tmpFile = tempnam($tmpDir, 'tmp');
+        if (!empty($tmpFile)) {
+            try {
+                $contents = $compiler($file->getContents());
+                $target   = preg_replace('/\.tpl$/', '', $file->getRelativePathname());
+                // Put contents and upload tmp file to server
+                if (file_put_contents($tmpFile, $contents) > 0) {
+                    run('mkdir -p {{deploy_path}}/shared/' . dirname($target));
+                    upload($tmpFile, 'shared/' . $target);
+                    $success = true;
+                }
+            } catch (\Exception $e) {
+                $success = false;
+            }
+            // Delete tmp file
+            unlink($tmpFile);
+        }
+        if ($success) {
+            writeln(sprintf("<info>✔</info> %s", $file->getRelativePathname()));
+        } else {
+            writeln(sprintf("<fg=red>✘</fg=red> %s", $file->getRelativePathname()));
+        }
+    }
+})->desc('Make configure files for your stage');


### PR DESCRIPTION
In this PR:
- add `configure recipe`: this recipe to make configure files from templates. (See https://github.com/deployphp/deployer/issues/152)

Eg, Creating a template file in `/shared` folder, same directory structure with `/shared` folder on server.
```
|-- bin
|    |-- dep
|-- shared
|    |-- Config
|        |-- app.php.tpl
|-- vendor
|-- deploy.php
```
And simple content of app.php.tpl file:
```php
<?php
// app.php.tpl
$bool    = {{app.var.bool}};
$string  = '{{app.var.string}}';
$integer = {{app.var.integer}};
$float   = {{app.var.float}};
$array   = {{app.var.array}};
$null    = {{app.var.null}};
$empty   = {{app.var.empty}};
```
And in deploy.php file, i defined server and env vars:

```php
// deploy.php
server('dev-server', '192.168.1.2', 22)
    ->user('dev')
    ->forwardAgent()
    ->stage(['dev'])
    ->env('deploy_path', '/var/www/apps/dev')
    ->env('branch', 'develop')
    ->env('app.var.bool', true)
    ->env('app.var.string', 'abc')
    ->env('app.var.integer', 100)
    ->env('app.var.float', 10.05)
    ->env('app.var.array', array('a' => 1, 'b' => 2))
    ->env('app.var.null', null)
    ->env('app.var.empty', '""')
;
```
After run this task, remote server has /shared/Config/app.php with contents:
```php
<?php
// app.php.tpl
$bool    = true;
$string  = 'abc';
$integer = 100;
$float   = 10.05;
$array   = array(
    'a' => 1,
    'b' => 2
);
$null    = NULL;
$empty   = "";
```