### PR TITLE
Fix rsync scr not ending in '/'

### DIFF
--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -114,5 +114,5 @@ task('rsync', function() {
     $port = $server->getPort() ? ' -p' . $server->getPort() : '';
     $user = !$server->getUser() ? '' : $server->getUser() . '@';
 
-    runLocally("rsync -{$config['flags']} -e 'ssh$port' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} '$src' '$user$host:$dst/'");
+    runLocally("rsync -{$config['flags']} -e 'ssh$port' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} '$src/' '$user$host:$dst/'");
 })->desc('Rsync local->remote');


### PR DESCRIPTION
This simply adds "/" to end of src. I don't know how I could omit it... I swear it was there! If You tried to use it it would not work otherwise, it would send scr dir as a subdir to dst dir, which is not something most would want.