### PR TITLE
Remove completelly unneded outputing of git version

### DIFF
--- a/recipes/local.php
+++ b/recipes/local.php
@@ -14,7 +14,6 @@
 env('local_git_cache', function() {
     $gitVersion = runLocally('git version');
     $regs = [];
-    output()->write($gitVersion, true);
     if (preg_match('/((\d+\.?)+)/', $gitVersion, $regs)) {
         $version = $regs[1];
     } else {


### PR DESCRIPTION
I've seen changes @oanhnn made. I was intigued by output being written and I've noticed that echo wound up there unnecessary. Output isn't present in git_cache in common.php that was based on this, so I guess I forgot to make change @elfet requested there present here too.