### PR TITLE
fix issue relative path when uploading with ext-ssh2

### DIFF
--- a/recipes/configure.php
+++ b/recipes/configure.php
@@ -38,8 +38,9 @@ task('deploy:configure', function () {
 
     $finder   = new \Symfony\Component\Finder\Finder();
     $iterator = $finder
+        ->ignoreDotFiles(false)
         ->files()
-        ->name('*.tpl')
+        ->name('/\.tpl$/')
         ->in(__DIR__ . '/shared');
 
     $tmpDir = sys_get_temp_dir();

--- a/recipes/configure.php
+++ b/recipes/configure.php
@@ -43,6 +43,7 @@ task('deploy:configure', function () {
         ->in(__DIR__ . '/shared');
 
     $tmpDir = sys_get_temp_dir();
+    $deployDir = env('deploy_path');
 
     /* @var $file \Symfony\Component\Finder\SplFileInfo */
     foreach ($iterator as $file) {
@@ -55,8 +56,8 @@ task('deploy:configure', function () {
                 $target   = preg_replace('/\.tpl$/', '', $file->getRelativePathname());
                 // Put contents and upload tmp file to server
                 if (file_put_contents($tmpFile, $contents) > 0) {
-                    run('mkdir -p {{deploy_path}}/shared/' . dirname($target));
-                    upload($tmpFile, 'shared/' . $target);
+                    run("mkdir -p $deployDir/shared/" . dirname($target));
+                    upload($tmpFile, "$deployDir/shared/" . $target);
                     $success = true;
                 }
             } catch (\Exception $e) {


### PR DESCRIPTION
In this PR:
* fix issue relative path when uploading with ext-ssh2, refs https://github.com/deployphp/deployer/issues/387
* fix don't ignore dot file (Eg: `.env.tpl` in laravel 5)