### PR TITLE
add support for place holders in slack messages

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -21,7 +21,7 @@ You can provide also other configuration options:
     - {{stage}}
     - {{user}}
     - {{branch}}
-    - {{app_name}} - set through env('slack_app_name') and defaults to "app-name"
+    - {{app_name}}
  - *channel* - default is **#general**
  - *icon* - default is **:sunny:**
  - *username* - default is **Deploy**
@@ -33,6 +33,7 @@ You can provide also other configuration options:
 set('slack', [
     'token' => 'xoxp-...',
     'team' => 'team name',
+    'app' => 'app name',
 ]);
 ```
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -21,7 +21,7 @@ You can provide also other configuration options:
     - {{stage}}
     - {{user}}
     - {{branch}}
-    - {{app_name}} - set through env('slack_app_name') and defaults to app-name
+    - {{app_name}} - set through env('slack_app_name') and defaults to "app-name"
  - *channel* - default is **#general**
  - *icon* - default is **:sunny:**
  - *username* - default is **Deploy**

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -14,7 +14,14 @@ require 'vendor/deployphp/recipes/recipes/slack.php';
 
 You can provide also other configuration options:
 
- - *message* - default is **Deployment to '{$host}' on *{$prod}* was successful\n({$releasePath})**
+ - *message* - default is **Deployment to `{{host}}` on *{{stage}}* was successful\n({{release_path}})**
+  - the available placeholders for the message parameter are:
+    - {{release_path}}
+    - {{host}}
+    - {{stage}}
+    - {{user}}
+    - {{branch}}
+    - {{app_name}} - set through env('slack_app_name') and defaults to app-name
  - *channel* - default is **#general**
  - *icon* - default is **:sunny:**
  - *username* - default is **Deploy**

--- a/recipes/slack.php
+++ b/recipes/slack.php
@@ -14,16 +14,33 @@ task('deploy:slack', function () {
     $config = get('slack', []);
 
     if (!isset($config['message'])) {
-        $releasePath = env('release_path');
-        $host = env('server.host');
-        $stage = env('stages')[0];
-        $config['message'] = "Deployment to '{$host}' on *{$stage}* was successful\n($releasePath)";
+        $config['message'] = "Deployment to `{{host}}` on *{{stage}}* was successful\n({{release_path}})";
     }
+
+    try {
+        env('slack_app_name');
+    } catch(\RuntimeException $e) {
+        env('slack_app_name', 'app-name');
+    }
+
+    $server = \Deployer\Task\Context::get()->getServer()->getConfiguration();
+    $host = $server->getHost();
+    $user = !$server->getUser() ? null : $server->getUser();
+    $messagePlaceHolders = [
+        '{{release_path}}' => env('release_path'),
+        '{{host}}' => env('server.host'),
+        '{{stage}}' => env('stages')[0],
+        '{{user}}' => $user,
+        '{{branch}}' => env('branch'),
+        '{{app_name}}' => env('slack_app_name'),
+    ];
+    $config['message'] = strtr($config['message'], $messagePlaceHolders);
 
     $defaultConfig = [
         'channel' => '#general',
         'icon' => ':sunny:',
         'username' => 'Deploy',
+        'message' => "Deployment to `{{host}}` on *{{stage}}* was successful\n({{release_path}})";,
     ];
 
     $config = array_merge($defaultConfig, $config);
@@ -50,7 +67,6 @@ task('deploy:slack', function () {
     }
 
     $url = 'https://slack.com/api/chat.postMessage?' . http_build_query($urlParams);
-
     $result = @file_get_contents($url);
 
     if (!$result) {

--- a/recipes/slack.php
+++ b/recipes/slack.php
@@ -17,12 +17,6 @@ task('deploy:slack', function () {
         $config['message'] = "Deployment to `{{host}}` on *{{stage}}* was successful\n({{release_path}})";
     }
 
-    try {
-        env('slack_app_name');
-    } catch(\RuntimeException $e) {
-        env('slack_app_name', 'app-name');
-    }
-
     $server = \Deployer\Task\Context::get()->getServer()->getConfiguration();
     $host = $server->getHost();
     $user = !$server->getUser() ? null : $server->getUser();
@@ -32,7 +26,7 @@ task('deploy:slack', function () {
         '{{stage}}' => env('stages')[0],
         '{{user}}' => $user,
         '{{branch}}' => env('branch'),
-        '{{app_name}}' => env('slack_app_name'),
+        '{{app_name}}' => env()->get('slack_app_name', 'app-name'),
     ];
     $config['message'] = strtr($config['message'], $messagePlaceHolders);
 
@@ -40,7 +34,7 @@ task('deploy:slack', function () {
         'channel' => '#general',
         'icon' => ':sunny:',
         'username' => 'Deploy',
-        'message' => "Deployment to `{{host}}` on *{{stage}}* was successful\n({{release_path}})";,
+        'message' => "Deployment to `{{host}}` on *{{stage}}* was successful\n({{release_path}})",
     ];
 
     $config = array_merge($defaultConfig, $config);

--- a/recipes/slack.php
+++ b/recipes/slack.php
@@ -26,7 +26,7 @@ task('deploy:slack', function () {
         '{{stage}}' => env('stages')[0],
         '{{user}}' => $user,
         '{{branch}}' => env('branch'),
-        '{{app_name}}' => env()->get('slack_app_name', 'app-name'),
+        '{{app_name}}' => isset($config['app']) ? ['app'] : 'app-name',
     ];
     $config['message'] = strtr($config['message'], $messagePlaceHolders);
 


### PR DESCRIPTION
I wanted to customize the message sent to slack, but found it hard to find the available variables. Also it wasn't clear to me how to add the name of the user deploying... so here is my proposal (more place holders should/could be added - like the tag name when available for instance - but those serve my needs for now).