### PR TITLE
prevent rsync without $dst set

### DIFF
--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -110,6 +110,13 @@ task('rsync', function() {
         $dst = $dst();
     }
 
+    if (!trim($dst)) {
+        // if $dst is not set here we are going to sync to root
+        // and even worse - depending on rsync flags and permission -
+        // might end up deleting everything we have write permission to
+        throw new \RuntimeException('You need to specify a destination path.');
+    }
+
     $server = \Deployer\Task\Context::get()->getServer()->getConfiguration();
     $host = $server->getHost();
     $port = $server->getPort() ? ' -p' . $server->getPort() : '';

--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -105,6 +105,14 @@ task('rsync', function() {
     while (is_callable($src)) {
         $src = $src();
     }
+
+    if (!trim($src)) {
+        // if $src is not set here rsync is going to do a directory listing
+        // exiting with code 0, since only doing a directory listing clearly
+        // is not what we want to achieve we need to throw an exception
+        throw new \RuntimeException('You need to specify a source path.');
+    }
+
     $dst = env('rsync_dest');
     while (is_callable($dst)) {
         $dst = $dst();


### PR DESCRIPTION
if $dst is not set here we are going to sync to root and even worse - depending on rsync flags and permission - might end up deleting everything we have write permission to