### PR TITLE
rsync recipe doesn't use identityFile

### DIFF
--- a/recipes/rsync.php
+++ b/recipes/rsync.php
@@ -128,7 +128,8 @@ task('rsync', function() {
     $server = \Deployer\Task\Context::get()->getServer()->getConfiguration();
     $host = $server->getHost();
     $port = $server->getPort() ? ' -p' . $server->getPort() : '';
+    $identityFile = $server->getPrivateKey() ? ' -i ' . $server->getPrivateKey() : '';
     $user = !$server->getUser() ? '' : $server->getUser() . '@';
 
-    runLocally("rsync -{$config['flags']} -e 'ssh$port' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} '$src/' '$user$host:$dst/'", $config['timeout']);
+    runLocally("rsync -{$config['flags']} -e 'ssh$port$identityFile' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} '$src/' '$user$host:$dst/'", $config['timeout']);
 })->desc('Rsync local->remote');


### PR DESCRIPTION
Even when set, the rsync command doesn't use the identityFile given from server configuration. Instead it will ask for password of the user.
Changed to use the identityFile. Passphrase would be asked anyway, as sshpass or any other similar program may not be available on the system. To use it the 'easy' way, creating a keyfile w/o passphrase would be a way, but security risk too.