### PR TITLE
Fixed the link to the Slack Api Token page

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -10,7 +10,7 @@ require 'vendor/deployphp/recipes/recipes/slack.php';
 
 ### Configuration options
 
-- **slack** *(required)*: accepts an *array* with the api token and team name. Token can be generated on [slack api website](https://api.slack.com/web]).
+- **slack** *(required)*: accepts an *array* with the api token and team name. Token can be generated on [slack api website](https://api.slack.com/docs/oauth-test-tokens).
 
 You can provide also other configuration options:
 


### PR DESCRIPTION
The link had a typo and was out-dated.
Not anymore!