### PR TITLE
Add a slack_skip_notification environment variable

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -8,6 +8,10 @@
 require 'vendor/deployphp/recipes/recipes/slack.php';
 ```
 
+### Environmental variables
+
+- **slack_skip_notification** - Skips the entire task when set to `true`. This is particularly useful if you want to disable slack notifications for certain stages.
+
 ### Configuration options
 
 - **slack** *(required)*: accepts an *array* with the api token and team name. Token can be generated on [slack api website](https://api.slack.com/docs/oauth-test-tokens).

--- a/recipes/slack.php
+++ b/recipes/slack.php
@@ -33,7 +33,7 @@ task('deploy:slack', function () {
         'app'      => 'app-name',
     ];
 
-    $config = array_merge($defaultConfig, (array) get('slack', []));
+    $config = array_merge($defaultConfig, (array) get('slack'));
 
     if (!is_array($config) || !isset($config['token']) || !isset($config['team']) || !isset($config['channel'])) {
         throw new \RuntimeException("Please configure new slack: set('slack', ['token' => 'xoxp...', 'team' => 'team', 'channel' => '#channel', 'messsage' => 'message to send']);");

--- a/recipes/slack.php
+++ b/recipes/slack.php
@@ -16,7 +16,7 @@ env('local_user', function () {
  * Notify Slack of successful deployment
  */
 task('deploy:slack', function () {
-    if (true === env('slack_skip_notification')) {
+    if (true === env('slack_skip_notification', false)) {
         return;
     }
 

--- a/recipes/slack.php
+++ b/recipes/slack.php
@@ -16,6 +16,10 @@ env('local_user', function () {
  * Notify Slack of successful deployment
  */
 task('deploy:slack', function () {
+    if (true === env('slack_skip_notification')) {
+        return;
+    }
+
     global $php_errormsg;
 
     $defaultConfig = [

--- a/recipes/slack.php
+++ b/recipes/slack.php
@@ -12,11 +12,14 @@ env('local_user', function () {
     return trim(run("whoami"));
 });
 
+// Skip slack notifications by default
+env('slack_skip_notification', true);
+
 /**
  * Notify Slack of successful deployment
  */
 task('deploy:slack', function () {
-    if (true === env('slack_skip_notification', false)) {
+    if (true === env('slack_skip_notification')) {
         return;
     }
 


### PR DESCRIPTION
This allows you to disable the slack task all together for certain servers, since `env` variables can be set / overridden for each server, while keeping the `slack` task active.
