### PR TITLE
Adding a Bugsnag recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ require 'vendor/deployer/recipes/cachetool.php';
 
 | Recipe     | Docs                       | Usage
 | ------     | ----                       | -----
+| bugsnag    | [read](docs/bugsnag.md)    | `require 'vendor/deployer/recipes/bugsnag.php';`
 | cachetool  | [read](docs/cachetool.md)  | `require 'vendor/deployer/recipes/cachetool.php';`
 | cloudflare | [read](docs/cloudflare.md) | `require 'vendor/deployer/recipes/cloudflare.php';`
 | hipchat    | [read](docs/hipchat.md)    | `require 'vendor/deployer/recipes/hipchat.php';`

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -1,0 +1,52 @@
+<?php
+/* (c) Tim Robertson <funkjedi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer;
+
+desc('Notifying Bugsnag of deployment');
+task('deploy:bugsnag', function () {
+    global $php_errormsg;
+
+    $defaultConfig = [
+        'api_key'       => null,
+        'release_stage' => env('stages')[0],
+        'repository'    => env('repository'),
+        'provider'      => null,
+        'branch'        => env('branch'),
+        'revision'      => trim(runLocally('git log -n 1 --format="%h"')),
+        'app_version'   => null,
+    ];
+
+    $config = array_merge($defaultConfig, (array) get('bugsnag'));
+
+    if (!is_array($config) || !isset($config['api_key'])) {
+        throw new \RuntimeException("Please configure new bugsnag: set('bugsnag', ['api_key' => 'c09a3...', 'release_stage' => 'production']);");
+    }
+
+    $postdata = [
+        'apiKey'       => $config['api_key'],
+        'releaseStage' => $config['release_stage'],
+        'repository'   => $config['repository'],
+        'provider'     => $config['provider'],
+        'branch'       => $config['branch'],
+        'revision'     => $config['revision'],
+        'appVersion'   => $config['app_version'],
+    ];
+
+    $options = array('http' => array(
+        'method' => 'POST',
+        'header' => "Content-type: application/json\r\n",
+        'content' => json_encode($postdata),
+    ));
+
+    $context = stream_context_create($options);
+    $result = @file_get_contents('https://notify.bugsnag.com/deploy', false, $context);
+
+    if (!$result) {
+        throw new \RuntimeException($php_errormsg);
+    }
+});

--- a/docs/bugsnag.md
+++ b/docs/bugsnag.md
@@ -1,0 +1,45 @@
+# Bugsnag recipe
+
+### Installing
+
+```php
+// deploy.php
+
+require 'vendor/deployphp/recipes/bugsnag.php';
+```
+
+### Configuration options
+
+- **bugsnag** *(required)*: accepts an *array* with the api_key. Key is given by the [Bugsnag website](https://bugsnag.com/).
+
+You can provide also other configuration options:
+
+- *api_key* - The API Key associated with the project. Informs Bugsnag which project has been deployed. This is the only required field.
+- *release_stage* - The release stage (eg, production, staging) currently being deployed. (Optional, defaults to **{{stage}}**.)
+- *repository* - The URL of the repository containing the source code being deployed. (Optional, defaults to **{{repository}}**.)
+- *provider* - The name of your source control provider. Required when repository is supplied and only for on-premise services.
+- *branch* - The source control branch from which you are deploying the code. (Optional, defaults to **{{branch}}**.)
+- *revision* - The source control revision id for the code you are deploying. (Optional defaults to `git log -n 1 --format="%h"`.)
+- *app_version* - The app version of the code you are currently deploying. Only set this if you tag your releases with semantic version numbers and deploy infrequently. (Optional.)
+
+```php
+// deploy.php
+
+set('bugsnag', [
+    'api_key' => "daf9a694....",
+]);
+```
+
+### Tasks
+
+- `deploy:bugsnag` send message to Bugsnag
+
+### Suggested Usage
+
+Since you should only notify Bugsnag of a successfull deployment, the `deploy:bugsnag` task should be executed right at the end.
+
+```php
+// deploy.php
+
+after('deploy', 'deploy:bugsnag');
+```


### PR DESCRIPTION
Notify Bugsnag about any new deploys or releases of your applications.

By sending the source revision or application version when you deploy a new version of your app, you’ll be able to see which deploy each error was introduced in.

https://docs.bugsnag.com/api/deploy-tracking/