### PR TITLE
Fix rsync:warmup task

### DIFF
--- a/rsync.php
+++ b/rsync.php
@@ -89,12 +89,10 @@ desc('Warmup remote Rsync target');
 task('rsync:warmup', function() {
     $config = get('rsync');
 
-    $releases = get('releases_list');
+    $source = "{{deploy_path}}/current";
+    $destination = "{{deploy_path}}/release";
 
-    if (isset($releases[1])) {
-        $source = "{{deploy_path}}/releases/{$releases[1]}";
-        $destination = "{{deploy_path}}/releases/{$releases[0]}";
-
+    if (run("if [ -d $(echo $source) ]; then echo true; fi")->toBool()) {
         run("rsync -{$config['flags']} {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} $source/ $destination/");
     } else {
         writeln("<comment>No way to warmup rsync.</comment>");


### PR DESCRIPTION
With new release management (in deployer 4.0), `rsync:warmup` do not work anymore.

This PR fix #77. 
It use `current` and `release` symlinks to copy previous release code in new release directory.