### PR TITLE
Run npm install locally

### DIFF
--- a/npm.php
+++ b/npm.php
@@ -24,7 +24,7 @@ task('npm:install', function () {
 });
 
 desc('Install npm packages');
-task('npm:install_local', function () {
+task('npm:local:install', function () {
   $releases = get('local_releases_list');
 
   if (isset($releases[1])) {

--- a/npm.php
+++ b/npm.php
@@ -23,6 +23,10 @@ task('npm:install', function () {
     run("cd {{release_path}} && {{bin/npm}} install");
 });
 
+set('local/bin/npm', function () {
+  return (string)runLocally('which npm');
+});
+
 desc('Install npm packages');
 task('npm:local:install', function () {
   $releases = get('local_releases_list');

--- a/npm.php
+++ b/npm.php
@@ -22,3 +22,15 @@ task('npm:install', function () {
     }
     run("cd {{release_path}} && {{bin/npm}} install");
 });
+
+desc('Install npm packages');
+task('npm:install_local', function () {
+  $releases = get('local_releases_list');
+
+  if (isset($releases[1])) {
+    if (runLocally("if [ -d {{local_deploy_path}}/releases/{$releases[1]}/node_modules ]; then echo 'true'; fi")->toBool()) {
+      runLocally("cp -R {{local_deploy_path}}/releases/{$releases[1]}/node_modules {{local_release_path}}");
+    }
+  }
+  runLocally("cd {{local_release_path}} && {{local/bin/npm}} install");
+});


### PR DESCRIPTION
The `npm` recipe supports running `npm install` on a server. When using the `local` recipe it would be nice to be able to run `npm install` locally and then deploy the result.

This PR adds a new task to the `npm` recipe which does that: `npm:install_local`.

A couple of comments:
- The current implementation is quite naive. Suggestions on how to improve it are appreciated.
- This is in essence an integration between two recipes. I do not know in which the result should live. I opted for the `npm` recipe for now.
- If you like the PR I will update the documentation.