### PR TITLE
Use New Relic Deployment API V2

### DIFF
--- a/docs/newrelic.md
+++ b/docs/newrelic.md
@@ -10,16 +10,14 @@ require 'vendor/deployer/recipes/newrelic.php';
 
 ### Configuration options
 
-- **newrelic** *(required)*: accepts an *array* with the license key for you new relic application and its application_id or app_name.
+- **newrelic** *(required)*: accepts an *array* with the api key for you new relic application and its application id.
 
 ```php
 // deploy.php
 
 set('newrelic', [
-    'license'        => 'xad3...',
+    'api_key'        => 'xad3...',
     'application_id' => '12873',
-    // or
-    'app_name' => 'your_app_name'
 ]);
 ```
 


### PR DESCRIPTION
[V1 has been deprecated](https://docs.newrelic.com/docs/apis/rest-api-v1-deprecated/new-relic-rest-api-v1/working-new-relic-rest-api-v1-deprecated#deploy). This means we now post JSON encoded data to a 
new endpoint.

Warn existing users that configuration values `app_name` and `license` have 
been replaced by `application_id` and `api_key`.

See https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/recording-deployments