### PR TITLE
slack: do not use deprecated env()

### DIFF
--- a/slack.php
+++ b/slack.php
@@ -1,5 +1,6 @@
 <?php
 /* (c) Tomas Majer <tomasmajer@gmail.com>
+/* (c) Elan Ruusamäe <glen@delfi.ee>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -40,11 +41,11 @@ task('deploy:slack', function () {
                 'text' => sprintf(
                     'Revision %s deployed to %s by %s',
                     substr($revision, 0, 6),
-                    env('stages')[0],
+                    get('stages')[0],
                     $user
                 ),
                 'title'    => 'Deployment Complete',
-                'fallback' => sprintf('Deployment to %s complete.', env('stages')[0]),
+                'fallback' => sprintf('Deployment to %s complete.', get('stages')[0]),
                 'color'    => '#7CD197',
                 'fields'   => [
                     [
@@ -54,17 +55,17 @@ task('deploy:slack', function () {
                     ],
                     [
                         'title' => 'Stage',
-                        'value' => env('stages')[0],
+                        'value' => get('stages')[0],
                         'short' => true,
                     ],
                     [
                         'title' => 'Branch',
-                        'value' => env('branch'),
+                        'value' => get('branch'),
                         'short' => true,
                     ],
                     [
                         'title' => 'Host',
-                        'value' => env('server.name'),
+                        'value' => get('server.name'),
                         'short' => true,
                     ],
                 ],

--- a/slack.php
+++ b/slack.php
@@ -28,6 +28,8 @@ task('deploy:slack', function () {
 
     $user = trim(runLocally('git config --get user.name'));
     $revision = trim(runLocally('git log -n 1 --format="%h"'));
+    $stage = get('stages')[0];
+    $branch = get('branch');
 
     $defaultConfig = [
         'channel'     => '#general',
@@ -41,11 +43,11 @@ task('deploy:slack', function () {
                 'text' => sprintf(
                     'Revision %s deployed to %s by %s',
                     substr($revision, 0, 6),
-                    get('stages')[0],
+                    $stage,
                     $user
                 ),
                 'title'    => 'Deployment Complete',
-                'fallback' => sprintf('Deployment to %s complete.', get('stages')[0]),
+                'fallback' => sprintf('Deployment to %s complete.', $stage),
                 'color'    => '#7CD197',
                 'fields'   => [
                     [
@@ -55,12 +57,12 @@ task('deploy:slack', function () {
                     ],
                     [
                         'title' => 'Stage',
-                        'value' => get('stages')[0],
+                        'value' => $stage,
                         'short' => true,
                     ],
                     [
                         'title' => 'Branch',
-                        'value' => get('branch'),
+                        'value' => $branch,
                         'short' => true,
                     ],
                     [
@@ -95,9 +97,9 @@ task('deploy:slack', function () {
     $messagePlaceHolders = [
         '{{release_path}}' => get('release_path'),
         '{{host}}'         => get('server.host'),
-        '{{stage}}'        => get('stages')[0],
+        '{{stage}}'        => $stage,
         '{{user}}'         => $user,
-        '{{branch}}'       => get('branch'),
+        '{{branch}}'       => $branch,
         '{{app_name}}'     => isset($config['app']) ? $config['app'] : 'app-name',
     ];
     $config['message'] = strtr($config['message'], $messagePlaceHolders);


### PR DESCRIPTION
this gives fatal error with v4.0.2

```                                                                 
  [RuntimeException]                                                 
  env() function deprecated. Please, use set() or get() instead of.  
```