### PR TITLE
Raise default rsync timeout

### DIFF
--- a/rsync.php
+++ b/rsync.php
@@ -20,7 +20,7 @@ set('rsync', [
     'filter-perdir' => false,
     'flags' => 'rz',
     'options' => ['delete'],
-    'timeout' => 60,
+    'timeout' => 300,
 ]);
 
 set('rsync_src', __DIR__);


### PR DESCRIPTION
The default timeout for local commands [was raised to 300 seconds](https://github.com/deployphp/deployer/commit/9680b11cc4fad7d83abb79ad16eb4ea9fd2ba0c2), thus do not lower this by default.