### PR TITLE
Changed the parameter api_key to license

### DIFF
--- a/docs/newrelic.md
+++ b/docs/newrelic.md
@@ -16,7 +16,7 @@ require 'vendor/deployer/recipes/newrelic.php';
 // deploy.php
 
 set('newrelic', [
-    'api_key'        => 'xad3...',
+    'license'        => 'xad3...',
     'application_id' => '12873',
 ]);
 ```


### PR DESCRIPTION
This is necessary because the newrelic.php script checks the license array.