### PR TITLE
"Make unsets if other fieldParams are set" logic more compact

### DIFF
--- a/slack.php
+++ b/slack.php
@@ -8,11 +8,11 @@
 
 namespace Deployer;
 
-/**
+/*
  * Get local username
  */
 set('local_user', function () {
-    return trim(run("whoami"));
+    return trim(run('whoami'));
 });
 
 // Do not skip slack notifications by default
@@ -76,8 +76,8 @@ task('deploy:slack', function () {
                         'short' => true,
                     ],
                 ],
-            ]
-        ]
+            ],
+        ],
     ];
 
     $newConfig = get('slack');
@@ -96,7 +96,7 @@ task('deploy:slack', function () {
     if ($server instanceof \Deployer\Server\Local) {
         $user = get('local_user');
     } else {
-        $user = $server->getConfiguration()->getUser() ? : null;
+        $user = $server->getConfiguration()->getUser() ?: null;
     }
 
     $messagePlaceHolders = [
@@ -105,7 +105,7 @@ task('deploy:slack', function () {
         '{{stage}}'        => $stage,
         '{{user}}'         => $user,
         '{{branch}}'       => $branch,
-        '{{app_name}}'     => isset($config['app']) ? $config['app'] : 'app-name',
+        '{{app_name}}'     => $config['app'] ?? 'app-name',
     ];
     $config['message'] = strtr($config['message'], $messagePlaceHolders);
 
@@ -115,11 +115,13 @@ task('deploy:slack', function () {
         'text'       => $config['message'],
         'username'   => $config['username'],
         'icon_emoji' => $config['icon'],
-        'pretty'     => true
+        'pretty'     => true,
     ];
 
-    if ($config['unset_text']) {
-        unset($urlParams['text']);
+    foreach (['unset_text' => 'text', 'icon_url' => 'icon_emoji'] as $set => $unset) {
+        if (isset($config[$set])) {
+            unset($urlParams[$unset]);
+        }
     }
 
     foreach (['parse', 'link_names', 'icon_url', 'unfurl_links', 'unfurl_media', 'as_user'] as $option) {
@@ -130,10 +132,6 @@ task('deploy:slack', function () {
 
     if (isset($config['attachments'])) {
         $urlParams['attachments'] = json_encode($config['attachments']);
-    }
-
-    if (isset($config['icon_url'])) {
-        unset($urlParams['icon_emoji']);
     }
 
     $url = 'https://slack.com/api/chat.postMessage?' . http_build_query($urlParams);


### PR DESCRIPTION
and some formatting. 
There are 2 more things which I would like to change, but wasn't sure about. 

The first thing is the ```global $php_errormsg```. Is it possible to delete that line and just remove the @ at the ```file_get_content``` or wouldn't it work anymore afterwards?

The second thing is, that I wanted to get rid of some local variables and outsource them to their own set calls, like ```local_user ```. Namely I thought about the `$user`, `$revision`, `$stage` and `$branch` variables.