### PR TITLE
fix for deployphp/recipes#112

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -47,7 +47,7 @@ task('deploy:configure', function() {
     $iterator = $finder
         ->files()
         ->name('*.tpl')
-        ->in(__DIR__ . '/shared');
+        ->in(getcwd() . '/shared');
     $tmpDir = sys_get_temp_dir();
 
     /* @var $file \Symfony\Component\Finder\SplFileInfo */


### PR DESCRIPTION
fixes the problem that
`__DIR__` returns `/path/to/project/vendor/deployer/recipes`
and not as expected `/path/to/project/`

For additional informations see #112  