### PR TITLE
Revert "Make rsync verbose on -vvv"

### DIFF
--- a/rsync.php
+++ b/rsync.php
@@ -127,10 +127,6 @@ task('rsync', function() {
         // might end up deleting everything we have write permission to
         throw new \RuntimeException('You need to specify a destination path.');
     }
-    
-    if (isVeryVerbose()) {
-        $config['flags'] .= 'v';
-    }
 
     $server = \Deployer\Task\Context::get()->getServer();
     if ($server instanceof \Deployer\Server\Local) {


### PR DESCRIPTION
Since this can generate a lot of output which cannot be prevented
if one wants to see command output at the same time, this is reverted
again. If required, one can simply configure rsync flags manually.

This reverts commit 1d87a76e7f3438c3455d53a2a389be59738c7fff.