### PR TITLE
Add breakpoint command to Phinx recipe

### DIFF
--- a/docs/phinx.md
+++ b/docs/phinx.md
@@ -12,8 +12,8 @@ require 'vendor/deployer/recipes/phinx.php';
 
 All options are in the environment variable `phinx` specified as a dictionary
 (instead of the `phinx_path` variable).
-All parameters are *optional*, but you can specify them with a dictionary(to change all parameters)
-or by deployer dot notation(to change one option).
+All parameters are *optional*, but you can specify them with a dictionary (to change all parameters)
+or by deployer dot notation (to change one option).
 
 #### Phinx environment variable
 
@@ -53,14 +53,15 @@ server('dev', 'my-dev-server.local')
 - `phinx:migrate` Migrate your database
 - `phinx:rollback` Rollback your database
 - `phinx:seed` Run seeds for your database
+- `phinx:breakpoint` Set a breakpoint for your database (note that breakpoints are toggled automatically by Phinx, so you will need to call this command once with the `--remove-all` option, then again to set the breakpoint to the current migration)
 
 ### Suggested Usage
 
-You can run all tasks after or before any 
-tasks(but you need to specify external configs for phinx).
-If you use internal configs(which are in your project) you need 
-to run it after `deploy:update_code` task is completed.
+You can run all tasks before or after any 
+tasks (but you need to specify external configs for phinx).
+If you use internal configs (which are in your project) you need 
+to run it after the `deploy:update_code` task is completed.
 
 ### Read more
 
-For further reading check the [phinx.org](https://phinx.org). Options description are on the [commands page](http://docs.phinx.org/en/latest/commands.html).
+For further reading see [phinx.org](https://phinx.org). Complete descriptions of all possible options can be found on the [commands page](http://docs.phinx.org/en/latest/commands.html).

--- a/phinx.php
+++ b/phinx.php
@@ -21,8 +21,7 @@ namespace Deployer;
  *
  * @return Path to Phinx
  */
-set(
-    'bin/phinx', function () {
+set('bin/phinx', function () {
         $isExistsCmd = 'if [ -f %s ]; then echo true; fi';
 
         try {
@@ -108,9 +107,8 @@ set('phinx_get_allowed_config', function () {
     };
 });
 
-desc('Migrating database by phinx');
-task(
-    'phinx:migrate', function () {
+desc('Migrating database with phinx');
+task('phinx:migrate', function () {
         $ALLOWED_OPTIONS = [
             'configuration',
             'date',
@@ -131,8 +129,8 @@ task(
     }
 );
 
-task(
-    'phinx:rollback', function () {
+desc('Rollback database migrations with phinx');
+task('phinx:rollback', function () {
         $ALLOWED_OPTIONS = [
             'configuration',
             'date',
@@ -153,8 +151,8 @@ task(
     }
 );
 
-task(
-    'phinx:seed', function () {
+desc('Seed database with phinx');
+task('phinx:seed', function () {
         $ALLOWED_OPTIONS = [
             'configuration',
             'environment',
@@ -174,3 +172,23 @@ task(
     }
 );
 
+desc('Set a migrations breakpoint with phinx');
+task('phinx:breakpoint', function () {
+        $ALLOWED_OPTIONS = [
+            'configuration',
+            'environment',
+            'remove-all',
+            'target'
+        ];
+
+        $conf = get('phinx_get_allowed_config')($ALLOWED_OPTIONS); 
+
+        cd('{{release_path}}');
+
+        $phinxCmd = get('phinx_get_cmd')('breakpoint', $conf);
+
+        run($phinxCmd);
+
+        cd('{{deploy_path}}');
+    }
+);


### PR DESCRIPTION
Also, update corresponding documentation.

Just thought it'd be helpful to add another method to the phinx recipe, as I need the ability to set a breakpoint before I run the latest migrations as a precaution, so I may roll back any incomplete migrations.