### PR TITLE
Yarn recipe added

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ require 'vendor/deployer/recipes/cachetool.php';
 | hipchat    | [read](docs/hipchat.md)    | `require 'vendor/deployer/recipes/hipchat.php';`
 | local      | [read](docs/local.md)      | `require 'vendor/deployer/recipes/local.php';`
 | newrelic   | [read](docs/newrelic.md)   | `require 'vendor/deployer/recipes/newrelic.php';`
+| npm        | [read](docs/npm.md)        | `require 'vendor/deployer/recipes/npm.php';`
 | phinx      | [read](docs/phinx.md)      | `require 'vendor/deployer/recipes/phinx.php'`
 | rabbit     | [read](docs/rabbit.md)     | `require 'vendor/deployer/recipes/rabbit.php';`
 | rsync      | [read](docs/rsync.md)      | `require 'vendor/deployer/recipes/rsync.php';`
 | slack      | [read](docs/slack.md)      | `require 'vendor/deployer/recipes/slack.php';`
 | sentry     | [read](docs/sentry.md)     | `require 'vendor/deployer/recipes/sentry.php';`
-| npm        | [read](docs/npm.md)        | `require 'vendor/deployer/recipes/npm.php';`
+| yarn       | [read](docs/yarn.md)       | `require 'vendor/deployer/recipes/yarn.php';`
 
 ## Contributing a recipe
 

--- a/docs/yarn.md
+++ b/docs/yarn.md
@@ -1,0 +1,32 @@
+# Yarn recipe
+
+### Installing
+
+```php
+// deploy.php
+
+require 'vendor/deployer/recipes/yarn.php';
+```
+
+### Configuration options
+
+- **bin/yarn** *(optional)*: set Yarn binary, automatically detected otherwise.
+- **local/bin/yarn** *(optional)*: set local Yarn binary, automatically detected otherwise. 
+
+By default, if no env setting is provided, this recipe will fallback to the global setting.
+
+### Tasks
+
+- `yarn:install` Install Yarn packages
+- `yarn:local:install` Install Yarn packages into a locally prepared release. This should be used with the [local recipe](docs/local.md).
+
+### Suggested Usage
+
+
+```php
+after('deploy:update_code', 'yarn:install');
+// or
+before('deploy:symlink', 'yarn:install');
+// or local
+after('local:update_code', 'yarn:local:install');
+```

--- a/yarn.php
+++ b/yarn.php
@@ -1,0 +1,41 @@
+<?php
+/* (c) Nick DeNardis <nick.denardis@gmail.com>
+ * (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer;
+
+set('bin/yarn', function () {
+    return (string)run('which yarn');
+});
+
+desc('Install Yarn packages');
+task('yarn:install', function () {
+    $releases = get('releases_list');
+
+    if (isset($releases[1])) {
+        if (run("if [ -d {{deploy_path}}/releases/{$releases[1]}/node_modules ]; then echo 'true'; fi")->toBool()) {
+            run("cp --recursive {{deploy_path}}/releases/{$releases[1]}/node_modules {{release_path}}");
+        }
+    }
+    run("cd {{release_path}} && {{bin/yarn}}");
+});
+
+set('local/bin/yarn', function () {
+  return (string)runLocally('which yarn');
+});
+
+desc('Install Yarn packages');
+task('yarn:local:install', function () {
+  $releases = get('local_releases_list');
+
+  if (isset($releases[1])) {
+    if (runLocally("if [ -d {{local_deploy_path}}/releases/{$releases[1]}/node_modules ]; then echo 'true'; fi")->toBool()) {
+      runLocally("cp -R {{local_deploy_path}}/releases/{$releases[1]}/node_modules {{local_release_path}}");
+    }
+  }
+  runLocally("cd {{local_release_path}} && {{local/bin/yarn}}");
+});


### PR DESCRIPTION
*Adding Yarn support, inspired by the NPM recipe.*

# Yarn recipe

### Installing

```php
// deploy.php

require 'vendor/deployer/recipes/yarn.php';
```

### Configuration options

- **bin/yarn** *(optional)*: set Yarn binary, automatically detected otherwise.
- **local/bin/yarn** *(optional)*: set local Yarn binary, automatically detected otherwise. 

By default, if no env setting is provided, this recipe will fallback to the global setting.

### Tasks

- `yarn:install` Install Yarn packages
- `yarn:local:install` Install Yarn packages into a locally prepared release. This should be used with the [local recipe](docs/local.md).

### Suggested Usage


```php
after('deploy:update_code', 'yarn:install');
// or
before('deploy:symlink', 'yarn:install');
// or local
after('local:update_code', 'yarn:local:install');
```