### PR TITLE
Not getting actual pem file path in rsync

### DIFF
--- a/recipe/rsync.php
+++ b/recipe/rsync.php
@@ -137,8 +137,10 @@ task('rsync', function() {
     $server = $server->getConfiguration();
     $host = $server->getHost();
     $port = $server->getPort() ? ' -p' . $server->getPort() : '';
-    $identityMethod = $server->getPemFile() ?: ($server->getPrivateKey() ?: false);
-    $identityFile = $identityMethod ? ' -i ' . $identityMethod : '';
+    $identityFile = '';
+    if($server->getPemFile() || $server->getPrivateKey()){
+        $identityFile = ' -i ' . ($server->getPemFile() ? $server->getPemFile() : $server->getPrivateKey());
+    }
     $user = !$server->getUser() ? '' : $server->getUser() . '@';
 
     runLocally("rsync -{$config['flags']} -e 'ssh$port$identityFile' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} '$src/' '$user$host:$dst/'", $config['timeout']);

--- a/recipe/rsync.php
+++ b/recipe/rsync.php
@@ -137,8 +137,8 @@ task('rsync', function() {
     $server = $server->getConfiguration();
     $host = $server->getHost();
     $port = $server->getPort() ? ' -p' . $server->getPort() : '';
-    $identityMethod = $server->getPemFile() ? 'getPemFile' : $server->getPrivateKey() ? 'getPrivateKey' : false;
-    $identityFile = $identityMethod ? ' -i ' . $server->$identityMethod() : '';
+    $identityMethod = $server->getPemFile() ?: ($server->getPrivateKey() ?: false);
+    $identityFile = $identityMethod ? ' -i ' . $identityMethod : '';
     $user = !$server->getUser() ? '' : $server->getUser() . '@';
 
     runLocally("rsync -{$config['flags']} -e 'ssh$port$identityFile' {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} '$src/' '$user$host:$dst/'", $config['timeout']);


### PR DESCRIPTION
The code was not setting actual identityFile path and only the identityMethod. This was causing the rsync failure. Here's the error. there is nothing after -i

[Symfony\Component\Process\Exception\ProcessFailedException]
 The command "rsync -rz -e 'ssh -p22 -i ' --delete --exclude='.git' --exclude='deploy.php' --exclude='node_modules' '/tmp/deployer/releases/20170417145717/' 'someuser@IPADDRESS:/home/ec2-user/staging/releases/4/'" failed.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/recipes/blob/master/CHANGELOG.md)
