### PR TITLE
rsync: Fixed naming for local deployments

### DIFF
--- a/recipe/rsync.php
+++ b/recipe/rsync.php
@@ -131,7 +131,7 @@ task('rsync', function() {
     }
 
     $server = \Deployer\Task\Context::get()->getHost();
-    if ($server instanceof \Deployer\Host\Local) {
+    if ($server instanceof \Deployer\Host\Localhost) {
         runLocally("rsync -{$config['flags']} {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} '$src/' '$dst/'", $config);
         return;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | Yes
| Deprecations? | No
| Fixed tickets | N/A

I realized during the review of the new PRs that the naming changed too, so I improved it in the rsync recipe. 
