### PR TITLE
Add sentry Custom server - 5.x

### DIFF
--- a/docs/sentry.md
+++ b/docs/sentry.md
@@ -18,6 +18,7 @@ require 'recipe/sentry.php';
 - **url** *(optional)* – a URL that points to the release. This can be the path to an online interface to the sourcecode for instance.
 - **date_started** *(optional)* – an optional date that indicates when the release process started.
 - **date_released** *(optional)* – an optional date that indicates when the release went live. If not provided the current time is assumed.
+- **sentry_server** *(optional)* – an optional sentry server (if you host it yourself). default to hosted sentry service.
 
 ```php
 // deploy.php

--- a/recipe/sentry.php
+++ b/recipe/sentry.php
@@ -17,6 +17,7 @@ task('deploy:sentry', function () {
         'url'           => null,
         'date_started'   => date("c"),
         'date_released'  => date("c"),
+        'sentry_server'  => 'https://sentry.io',
     ];
 
     $config = array_merge($defaultConfig, (array) get('sentry'));
@@ -40,7 +41,7 @@ task('deploy:sentry', function () {
     ));
 
     $context = stream_context_create($options);
-    $result = file_get_contents('https://sentry.io/api/0/projects/' . $config['organization'] . '/' . $config['project'] . '/releases/', false, $context);
+    $result = file_get_contents($config['sentry_server'] . '/api/0/projects/' . $config['organization'] . '/' . $config['project'] . '/releases/', false, $context);
 
     if (!$result) {
         throw new \RuntimeException($php_errormsg);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Add the ability to set a custom sentry server.