### PR TITLE
[BUGFIX] Replace run()->toBool() with test()

### DIFF
--- a/recipe/rsync.php
+++ b/recipe/rsync.php
@@ -94,7 +94,7 @@ task('rsync:warmup', function() {
     $source = "{{deploy_path}}/current";
     $destination = "{{deploy_path}}/release";
 
-    if (run("if [ -d $(echo $source) ]; then echo true; fi")->toBool()) {
+    if (test("[ -d $(echo $source) ]")) {
         run("rsync -{$config['flags']} {{rsync_options}}{{rsync_excludes}}{{rsync_includes}}{{rsync_filter}} $source/ $destination/");
     } else {
         writeln("<comment>No way to warmup rsync.</comment>");


### PR DESCRIPTION
To toBool() functionality has been dropped in deployer 6. 

This patch replaces the run()->toBool() call with test().

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | Yes
| Deprecations? | No
| Fixed tickets | N/A
