### PR TITLE
Fix incorrect task name

### DIFF
--- a/docs/rollbar.md
+++ b/docs/rollbar.md
@@ -29,8 +29,8 @@ require 'recipe/rollbar.php';
 
 ## Usage
 
-Since you should only notify Rollbar channel of a successfull deployment, the `deploy:rollbar` task should be executed right at the end.
+Since you should only notify Rollbar channel of a successfull deployment, the `rollbar:notify` task should be executed right at the end.
 
 ```php
-after('deploy', 'deploy:rollbar');
+after('deploy', 'rollbar:notify');
 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This change fixes usage instructions in the documentation as `deploy:rollbar` task doesn't exist and `rollbar:notify` is the actual task that should be used.
