### PR TITLE
Slack interg improve

### DIFF
--- a/slack.php
+++ b/slack.php
@@ -42,7 +42,6 @@ task('deploy:slack', function () {
         'username'    => 'Deploy',
         'message'     => "Deployment to `{{host}}` on *{{stage}}* was successful\n({{release_path}})",
         'app'         => 'app-name',
-        'unset_text'  => true,
         'attachments' => [
             [
                 'text' => sprintf(

--- a/slack.php
+++ b/slack.php
@@ -86,7 +86,7 @@ task('deploy:slack', function () {
     }
 
     $config = array_merge($defaultConfig, (array) $newConfig);
-    if(isset($newConfig['attachmentCustom'])){
+    if (isset($newConfig['attachmentCustom'])) {
         $config['attachments'][0] = array_merge($config['attachments'][0], $newConfig['attachmentCustom']);
     }
 

--- a/slack.php
+++ b/slack.php
@@ -71,7 +71,7 @@ task('deploy:slack', function () {
                     ],
                     [
                         'title' => 'Host',
-                        'value' => get('server.name'),
+                        'value' => get('server.host'),
                         'short' => true,
                     ],
                 ],
@@ -86,6 +86,9 @@ task('deploy:slack', function () {
     }
 
     $config = array_merge($defaultConfig, (array) $newConfig);
+    if(isset($newConfig['attachmentCustom'])){
+        $config['attachments'][0] = array_merge($config['attachments'][0], $newConfig['attachmentCustom']);
+    }
 
     if (!is_array($config) || !isset($config['token']) || !isset($config['team']) || !isset($config['channel'])) {
         throw new \RuntimeException("Please configure new slack: set('slack', ['token' => 'xoxp...', 'team' => 'team', 'channel' => '#channel', 'messsage' => 'message to send']);");


### PR DESCRIPTION
1. Fix prev commit "make unsets when other fieldParams are set logic more compact" - impossible to disable unset of `text` param. To turn ON unset of `text` just add `unset_text: true` to config.

2. Real hostname in **Host** attachment block.

3. Add customization of attachment color & title by adding to slack config `attachmentCustom`:
```
  slack:
    token: xoxp...
    ...
    attachmentCustom:
      color: '#a94442'
#      title: 'Деплой выполнен'
```