### PR TITLE
Updated the docs of the Slack recipe.

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -60,5 +60,5 @@ after('success', 'slack:notify:success');
 If you want to notify about failed deployment add this too:
 
 ```php
-after('deploy:failure', 'slack:notify:failure');
+after('deploy:failed', 'slack:notify:failure');
 ```


### PR DESCRIPTION
Replaced `after('deploy:failure', 'slack:notify:failure');` with `after('deploy:failed', 'slack:notify:failure');`

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

