### PR TITLE
Add yammer recipe and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - Added grafana recipe.
+- Added yammer recipe, based on Slack recipe.
 
 ## 6.0.2
 [6.0.1...6.0.2](https://github.com/deployphp/recipes/compare/6.0.1...6.0.2)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ require 'recipe/slack.php';
 | rsync      | [read](docs/rsync.md)     
 | sentry     | [read](docs/sentry.md)    
 | slack      | [read](docs/slack.md)     
+| yammer     | [read](docs/yammer.md)
 | yarn       | [read](docs/yarn.md)      
 | raygun     | [read](docs/raygun.md)      
 

--- a/docs/yammer.md
+++ b/docs/yammer.md
@@ -1,0 +1,60 @@
+# Yammer recipe
+
+## Installing
+
+Require yammer recipe in your `deploy.php` file:
+
+```php
+require 'recipe/yammer.php';
+```
+
+Add hook on deploy:
+ 
+```php
+before('deploy', 'yammer:notify');
+```
+
+## Configuration
+
+- `yammer_url` – The URL to the message endpoint, default is https://www.yammer.com/api/v1/messages.json
+- `yammer_token` *(required)* – Yammer auth token
+- `yammer_group_id` *(required)* - Group ID 
+- `yammer_title` – the title of application, default `{{application}}`
+- `yammer_body` – notification message template, default:
+  ```
+  <em>{{user}}</em> deploying {{branch}} to <strong>{{target}}</strong>
+  ```
+- `yammer_success_body` – success template, default:
+  ```
+  Deploy to <strong>{{target}}</strong> successful
+  ```
+- `yammer_failure_body` – failure template, default:
+  ```
+  Deploy to <strong>{{target}}</strong> failed
+  ```
+
+## Tasks
+
+- `yammer:notify` – send message to Yammer
+- `yammer:notify:success` – send success message to Yammer
+- `yammer:notify:failure` – send failure message to Yammer
+
+## Usage
+
+If you want to notify only about beginning of deployment add this line only:
+
+```php
+before('deploy', 'yammer:notify');
+```
+
+If you want to notify about successful end of deployment add this too:
+
+```php
+after('success', 'yammer:notify:success');
+```
+
+If you want to notify about failed deployment add this too:
+
+```php
+after('deploy:failed', 'yammer:notify:failure');
+```

--- a/recipe/yammer.php
+++ b/recipe/yammer.php
@@ -1,0 +1,82 @@
+<?php
+/* (c) beeete2 <beeete2@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer;
+
+use Deployer\Utility\Httpie;
+
+set('yammer_url', 'https://www.yammer.com/api/v1/messages.json');
+
+// Title of project
+set('yammer_title', function () {
+    return get('application', 'Project');
+});
+
+// Deploy message
+set('yammer_body', '<em>{{user}}</em> deploying {{branch}} to <strong>{{target}}</strong>');
+set('yammer_success_body', 'Deploy to <strong>{{target}}</strong> successful');
+set('yammer_failure_body', 'Deploy to <strong>{{target}}</strong> failed');
+
+desc('Notifying Yammer');
+task('yammer:notify', function () {
+    $params = [
+        'is_rich_text' => 'true',
+        'message_type' => 'announcement',
+        'group_id' => get('yammer_group_id'),
+        'title' => get('yammer_title'),
+        'body' => get('yammer_body'),
+    ];
+
+    Httpie::post(get('yammer_url'))
+        ->header('Authorization: Bearer ' . get('yammer_token'))
+        ->header('Content-type: application/json')
+        ->body($params)
+        ->send();
+})
+    ->once()
+    ->shallow()
+    ->setPrivate();
+
+desc('Notifying Yammer about deploy finish');
+task('yammer:notify:success', function () {
+    $params = [
+        'is_rich_text' => 'true',
+        'message_type' => 'announcement',
+        'group_id' => get('yammer_group_id'),
+        'title' => get('yammer_title'),
+        'body' => get('yammer_success_body'),
+    ];
+
+    Httpie::post(get('yammer_url'))
+        ->header('Authorization: Bearer ' . get('yammer_token'))
+        ->header('Content-type: application/json')
+        ->body($params)
+        ->send();
+})
+    ->once()
+    ->shallow()
+    ->setPrivate();
+
+desc('Notifying Yammer about deploy failure');
+task('yammer:notify:failure', function () {
+    $params = [
+        'is_rich_text' => 'true',
+        'message_type' => 'announcement',
+        'group_id' => get('yammer_group_id'),
+        'title' => get('yammer_title'),
+        'body' => get('yammer_failure_body'),
+    ];
+
+    Httpie::post(get('yammer_url'))
+        ->header('Authorization: Bearer ' . get('yammer_token'))
+        ->header('Content-type: application/json')
+        ->body($params)
+        ->send();
+})
+    ->once()
+    ->shallow()
+    ->setPrivate();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I have created Microsoft Yammer's integration. This recipe is based on Slack recipe.

Supported tasks.

- `yammer:notify` – send message to Yammer
- `yammer:notify:success` – send success message to Yammer
- `yammer:notify:failure` – send failure message to Yammer

In Yammer is looks like below.
![yammer_screenshot](https://user-images.githubusercontent.com/4465089/34467925-02bf0290-ef41-11e7-9c83-6ca4865e5d4f.png)
