### PR TITLE
Add comment quietly option to Rollbar recipe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Added grafana recipe.
 - Added yammer recipe, based on Slack recipe.
+- Added comment quietly option to Rollbar recipe.
 
 ## 6.0.2
 [6.0.1...6.0.2](https://github.com/deployphp/recipes/compare/6.0.1...6.0.2)

--- a/docs/rollbar.md
+++ b/docs/rollbar.md
@@ -21,7 +21,9 @@ require 'recipe/rollbar.php';
   ```php
   set('rollbar_comment', '_{{user}}_ deploying `{{branch}}` to *{{target}}*');
   ```
+  this parameter is required. but if you setting to `rollbar_quietly` is `true`, it will be optional parameter. 
 - `rollbar_username` – rollbar user name  
+- `rollbar_quietly` - not post the comment to rollbar. if it is not necessary to comment, set `true`. default `false`. 
 
 ### Tasks
 

--- a/recipe/rollbar.php
+++ b/recipe/rollbar.php
@@ -17,13 +17,18 @@ task('rollbar:notify', function () {
         return;
     }
 
+    $comment = get('rollbar_comment');
+    if (get('rollbar_quietly', false)) {
+        $comment = '';
+    }
+
     $params = [
         'access_token' => get('rollbar_token'),
         'environment' => get('target'),
         'revision' => runLocally('git log -n 1 --format="%h"'),
         'local_username' => get('user'),
-        'rollbar_username' => get('rollbar_username'),
-        'comment' => get('rollbar_comment'),
+        'rollbar_username' => get('rollbar_username', ''),
+        'comment' => $comment,
     ];
 
     Httpie::post('https://api.rollbar.com/api/1/deploy/')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #154 

I changed the Rollbar recipe.
But I keeping compatibility.

When executed with the setting before change.
- rollbar_username is required parameter
- if comment is not set, default comment is set
```php
set('rollbar_token', 'set your rollbar token');
set('target', 'production');
set('user', 'deployer');
set('branch', 'release');
set('rollbar_username', 'beeete2'); // required parameter
```
The execution result does not change before and after the change.

![image1](https://user-images.githubusercontent.com/4465089/34774589-3c867a8a-f653-11e7-9ffe-fdf49bae915f.png)


When executed with the new parameter.
- rollbar_username is optional parameter
- if you do not want to set comments, set `rollbar_quietly` to `true`

```php
set('rollbar_token', 'set your rollbar token');
set('target', 'production');
set('user', 'deployer');
set('branch', 'release');
set('rollbar_quietly', true); // add new parameter. default `false`
// set('rollbar_username', 'beeete2');
```

![image2](https://user-images.githubusercontent.com/4465089/34774632-6d257f6a-f653-11e7-97d7-bd1d3573fe8d.png)


Of course, if you set a comment, the comment you set will be preferentially set.
```php
set('rollbar_token', 'set your rollbar token');
set('target', 'production');
set('user', 'deployer');
set('branch', 'release');
set('rollbar_comment', 'test comment.');
```

![image3](https://user-images.githubusercontent.com/4465089/34774637-72030c64-f653-11e7-950c-6c5d012b67c1.png)
