### PR TITLE
extend slack recipe

### DIFF
--- a/recipe/slack.php
+++ b/recipe/slack.php
@@ -11,7 +11,7 @@ use Deployer\Utility\Httpie;
 
 // Title of project
 set('slack_title', function () {
-    return get('application', 'Project');
+	return get('application', 'Project');
 });
 
 // Deploy message
@@ -21,76 +21,102 @@ set('slack_failure_text', 'Deploy to *{{target}}* failed');
 
 // Color of attachment
 set('slack_color', '#4d91f7');
-set('slack_success_color', '{{slack_color}}');
-set('slack_failure_color', '#ff0909');
+set('slack_success_color', 'good');
+set('slack_failure_color', 'danger');
 
-// Other defaults
+// Username
 set('slack_username', 'Deployer');
+
+// Icon (Deployer icon by default)
+set('slack_icon_emoji', '');
+set('slack_icon_url', 'https://deployer.org/images/deployer-sticker.png');
+
+// Pretext
 set('slack_pretext', '');
-set('slack_icon', ':rocket:');
+set('slack_success_pretext', '');
+set('slack_failure_pretext', '');
 
 desc('Notifying Slack');
 task('slack:notify', function () {
-    if (!get('slack_webhook', false)) {
-        return;
-    }
+	if (!get('slack_webhook', false)) {
+		return;
+	}
 
-    $attachment = [
-        'username' => get('slack_username'),
-        'title' => get('slack_title'),
-        'pretext' => get('slack_pretext'),
-        'text' => get('slack_text'),
-        'color' => get('slack_color'),
-        'mrkdwn_in' => ['text', 'pretext'],
-        'icon_emoji' => get('slack_icon'),
-    ];
+	$messageContent = [
+		'username' => get('slack_username'),
+		'icon_emoji' => get('slack_icon_emoji'),
+		'icon_url' => get('slack_icon_url'),
+		'attachments' => [
+            [
+                'title' => get('slack_title'),
+                'pretext' => get('slack_pretext'),
+                'text' => get('slack_text'),
+                'color' => get('slack_color'),
+                'mrkdwn_in' => ['text', 'pretext'],
+		    ]
+        ],
+	];
 
-    Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();
+
+	Httpie::post(get('slack_webhook'))->body($messageContent)->send();
 })
-    ->once()
-    ->shallow()
-    ->setPrivate();
+	->once()
+	->shallow()
+	->setPrivate();
 
 desc('Notifying Slack about deploy finish');
 task('slack:notify:success', function () {
-    if (!get('slack_webhook', false)) {
-        return;
-    }
+	if (!get('slack_webhook', false)) {
+		return;
+	}
 
-    $attachment = [
-        'username' => get('slack_username'),
-        'title' => get('slack_title'),
-        'pretext' => get('slack_pretext'),
-        'text' => get('slack_success_text'),
-        'color' => get('slack_success_color'),
-        'mrkdwn_in' => ['text', 'pretext'],
-        'icon_emoji' => get('slack_icon'),
-    ];
+	$messageContent = [
+		'username' => get('slack_username'),
+		'icon_emoji' => get('slack_icon_emoji'),
+		'icon_url' => get('slack_icon_url'),
+		'attachments' => [
+                [
+                    'title' => get('slack_title'),
+                    'pretext' => get('slack_success_pretext'),
+                    'text' => get('slack_success_text'),
+                    'color' => get('slack_success_color'),
+                    'mrkdwn_in' => ['text', 'pretext'
+                ]
+            ],
+		],
+	];
 
-    Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();
+
+	Httpie::post(get('slack_webhook'))->body($messageContent)->send();
 })
-    ->once()
-    ->shallow()
-    ->setPrivate();
+	->once()
+	->shallow()
+	->setPrivate();
 
 desc('Notifying Slack about deploy failure');
 task('slack:notify:failure', function () {
-    if (!get('slack_webhook', false)) {
-        return;
-    }
+	if (!get('slack_webhook', false)) {
+		return;
+	}
 
-    $attachment = [
-        'username' => get('slack_username'),
-        'title' => get('slack_title'),
-        'pretext' => get('slack_pretext'),
-        'text' => get('slack_failure_text'),
-        'color' => get('slack_failure_color'),
-        'mrkdwn_in' => ['text', 'pretext'],
-        'icon_emoji' => get('slack_icon'),
-    ];
+	$messageContent = [
+		'username' => get('slack_username'),
+		'icon_emoji' => get('slack_icon_emoji'),
+		'icon_url' => get('slack_icon_url'),
+		'attachments' => [
+            [
+                'title' => get('slack_title'),
+                'pretext' => get('slack_failure_pretext'),
+                'text' => get('slack_failure_text'),
+                'color' => get('slack_failure_color'),
+                'mrkdwn_in' => ['text', 'pretext'],
+            ]
+        ],
+	];
 
-    Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();
+
+	Httpie::post(get('slack_webhook'))->body($messageContent)->send();
 })
-    ->once()
-    ->shallow()
-    ->setPrivate();
+	->once()
+	->shallow()
+	->setPrivate();

--- a/recipe/slack.php
+++ b/recipe/slack.php
@@ -31,10 +31,13 @@ task('slack:notify', function () {
     }
 
     $attachment = [
+        'username' => get('slack_username'),
         'title' => get('slack_title'),
+        'pretext' => get('slack_pretext'),
         'text' => get('slack_text'),
         'color' => get('slack_color'),
-        'mrkdwn_in' => ['text'],
+        'mrkdwn_in' => ['text', 'pretext'],
+        'icon_emoji' => get('slack_icon),
     ];
 
     Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();
@@ -50,10 +53,13 @@ task('slack:notify:success', function () {
     }
 
     $attachment = [
+        'username' => get('slack_username'),
         'title' => get('slack_title'),
+        'pretext' => get('slack_pretext'),
         'text' => get('slack_success_text'),
         'color' => get('slack_success_color'),
-        'mrkdwn_in' => ['text'],
+        'mrkdwn_in' => ['text', 'pretext'],
+        'icon_emoji' => get('slack_icon),
     ];
 
     Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();
@@ -69,10 +75,13 @@ task('slack:notify:failure', function () {
     }
 
     $attachment = [
+        'username' => get('slack_username'),
         'title' => get('slack_title'),
+        'pretext' => get('slack_pretext'),
         'text' => get('slack_failure_text'),
         'color' => get('slack_failure_color'),
-        'mrkdwn_in' => ['text'],
+        'mrkdwn_in' => ['text', 'pretext'],
+        'icon_emoji' => get('slack_icon),
     ];
 
     Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();

--- a/recipe/slack.php
+++ b/recipe/slack.php
@@ -24,6 +24,11 @@ set('slack_color', '#4d91f7');
 set('slack_success_color', '{{slack_color}}');
 set('slack_failure_color', '#ff0909');
 
+// Other defaults
+set('slack_username', 'Deployer');
+set('slack_pretext', '');
+set('slack_icon', ':rocket:');
+
 desc('Notifying Slack');
 task('slack:notify', function () {
     if (!get('slack_webhook', false)) {
@@ -37,7 +42,7 @@ task('slack:notify', function () {
         'text' => get('slack_text'),
         'color' => get('slack_color'),
         'mrkdwn_in' => ['text', 'pretext'],
-        'icon_emoji' => get('slack_icon),
+        'icon_emoji' => get('slack_icon'),
     ];
 
     Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();
@@ -59,7 +64,7 @@ task('slack:notify:success', function () {
         'text' => get('slack_success_text'),
         'color' => get('slack_success_color'),
         'mrkdwn_in' => ['text', 'pretext'],
-        'icon_emoji' => get('slack_icon),
+        'icon_emoji' => get('slack_icon'),
     ];
 
     Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();
@@ -81,7 +86,7 @@ task('slack:notify:failure', function () {
         'text' => get('slack_failure_text'),
         'color' => get('slack_failure_color'),
         'mrkdwn_in' => ['text', 'pretext'],
-        'icon_emoji' => get('slack_icon),
+        'icon_emoji' => get('slack_icon'),
     ];
 
     Httpie::post(get('slack_webhook'))->body(['attachments' => [$attachment]])->send();

--- a/recipe/slack.php
+++ b/recipe/slack.php
@@ -10,9 +10,12 @@ namespace Deployer;
 use Deployer\Utility\Httpie;
 
 // Title of project
-set('slack_title', function () {
-	return get('application', 'Project');
-});
+set(
+	'slack_title',
+	function () {
+		return get('application', 'Project');
+	}
+);
 
 // Deploy message
 set('slack_text', '_{{user}}_ deploying `{{branch}}` to *{{target}}*');
@@ -37,86 +40,97 @@ set('slack_success_pretext', '');
 set('slack_failure_pretext', '');
 
 desc('Notifying Slack');
-task('slack:notify', function () {
-	if (!get('slack_webhook', false)) {
-		return;
+task(
+	'slack:notify',
+	function () {
+		if (!get('slack_webhook', false)) {
+			return;
+		}
+
+		$messageContent = [
+			'username' => get('slack_username'),
+			'icon_emoji' => get('slack_icon_emoji'),
+			'icon_url' => get('slack_icon_url'),
+			'attachments' => [
+				[
+					'title' => get('slack_title'),
+					'pretext' => get('slack_pretext'),
+					'text' => get('slack_text'),
+					'color' => get('slack_color'),
+					'mrkdwn_in' => ['text', 'pretext'],
+				],
+			],
+		];
+
+
+		Httpie::post(get('slack_webhook'))->body($messageContent)->send();
 	}
-
-	$messageContent = [
-		'username' => get('slack_username'),
-		'icon_emoji' => get('slack_icon_emoji'),
-		'icon_url' => get('slack_icon_url'),
-		'attachments' => [
-            [
-                'title' => get('slack_title'),
-                'pretext' => get('slack_pretext'),
-                'text' => get('slack_text'),
-                'color' => get('slack_color'),
-                'mrkdwn_in' => ['text', 'pretext'],
-		    ]
-        ],
-	];
-
-
-	Httpie::post(get('slack_webhook'))->body($messageContent)->send();
-})
+)
 	->once()
 	->shallow()
 	->setPrivate();
 
 desc('Notifying Slack about deploy finish');
-task('slack:notify:success', function () {
-	if (!get('slack_webhook', false)) {
-		return;
+task(
+	'slack:notify:success',
+	function () {
+		if (!get('slack_webhook', false)) {
+			return;
+		}
+
+		$messageContent = [
+			'username' => get('slack_username'),
+			'icon_emoji' => get('slack_icon_emoji'),
+			'icon_url' => get('slack_icon_url'),
+			'attachments' => [
+				[
+					'title' => get('slack_title'),
+					'pretext' => get('slack_success_pretext'),
+					'text' => get('slack_success_text'),
+					'color' => get('slack_success_color'),
+					'mrkdwn_in' => [
+						'text',
+						'pretext',
+					],
+				],
+			],
+		];
+
+
+		Httpie::post(get('slack_webhook'))->body($messageContent)->send();
 	}
-
-	$messageContent = [
-		'username' => get('slack_username'),
-		'icon_emoji' => get('slack_icon_emoji'),
-		'icon_url' => get('slack_icon_url'),
-		'attachments' => [
-                [
-                    'title' => get('slack_title'),
-                    'pretext' => get('slack_success_pretext'),
-                    'text' => get('slack_success_text'),
-                    'color' => get('slack_success_color'),
-                    'mrkdwn_in' => ['text', 'pretext'
-                ]
-            ],
-		],
-	];
-
-
-	Httpie::post(get('slack_webhook'))->body($messageContent)->send();
-})
+)
 	->once()
 	->shallow()
 	->setPrivate();
 
 desc('Notifying Slack about deploy failure');
-task('slack:notify:failure', function () {
-	if (!get('slack_webhook', false)) {
-		return;
+task(
+	'slack:notify:failure',
+	function () {
+		if (!get('slack_webhook', false)) {
+			return;
+		}
+
+		$messageContent = [
+			'username' => get('slack_username'),
+			'icon_emoji' => get('slack_icon_emoji'),
+			'icon_url' => get('slack_icon_url'),
+			'attachments' => [
+				[
+					'title' => get('slack_title'),
+					'pretext' => get('slack_failure_pretext'),
+					'text' => get('slack_failure_text'),
+					'color' => get('slack_failure_color'),
+					'mrkdwn_in' => ['text', 'pretext'],
+				],
+			],
+		];
+
+
+		Httpie::post(get('slack_webhook'))->body($messageContent)->send();
 	}
-
-	$messageContent = [
-		'username' => get('slack_username'),
-		'icon_emoji' => get('slack_icon_emoji'),
-		'icon_url' => get('slack_icon_url'),
-		'attachments' => [
-            [
-                'title' => get('slack_title'),
-                'pretext' => get('slack_failure_pretext'),
-                'text' => get('slack_failure_text'),
-                'color' => get('slack_failure_color'),
-                'mrkdwn_in' => ['text', 'pretext'],
-            ]
-        ],
-	];
-
-
-	Httpie::post(get('slack_webhook'))->body($messageContent)->send();
-})
+)
 	->once()
 	->shallow()
 	->setPrivate();


### PR DESCRIPTION
add possibility to pass username, pretext and icon_emoji as attachments

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A