### PR TITLE
Fix telegram recipe and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added grafana recipe.
 - Added yammer recipe, based on Slack recipe.
 
+### Fixed
+
+- Fixed telegram recipe (#170) and updated docs
+
 ## 6.0.2
 [6.0.1...6.0.2](https://github.com/deployphp/recipes/compare/6.0.1...6.0.2)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ require 'recipe/slack.php';
 | rsync      | [read](docs/rsync.md)     
 | sentry     | [read](docs/sentry.md)    
 | slack      | [read](docs/slack.md)     
-| yammer     | [read](docs/yammer.md)
+| telegram   | [read](docs/telegram.md)
+| yammer     | [read](docs/yammer.md)
 | yarn       | [read](docs/yarn.md)      
 | raygun     | [read](docs/raygun.md)      
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -1,10 +1,9 @@
 # Telegram recipe
 
 ## Installing
-  1. Create telegram bot by any manual in the internet
-  2. Take telegrambot token from BotFather
-  3. Send /start to your bot and open https://api.telegram.org/bot{$TELEGRAM_TOKEN_HERE}/getUpdates
-  4. Take chat_id from response
+  1. Create telegram bot with [BotFather](https://t.me/BotFather) and grab the token provided
+  2. Send /start to your bot and open https://api.telegram.org/bot{$TELEGRAM_TOKEN_HERE}/getUpdates
+  3. Take chat_id from response
 Require telegram recipe in your `deploy.php` file:
 
 ```php

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -2,7 +2,7 @@
 
 ## Installing
   1. Create telegram bot with [BotFather](https://t.me/BotFather) and grab the token provided
-  2. Send /start to your bot and open https://api.telegram.org/bot{$TELEGRAM_TOKEN_HERE}/getUpdates
+  2. Send `/start` to your bot and open https://api.telegram.org/bot{$TELEGRAM_TOKEN_HERE}/getUpdates
   3. Take chat_id from response
 Require telegram recipe in your `deploy.php` file:
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -1,9 +1,9 @@
-# telegram recipe
+# Telegram recipe
 
 ## Installing
   1. Create telegram bot by any manual in the internet
   2. Take telegrambot token from BotFather
-  3. Send /start to your bot and open https://api.telegram.org/bot$TELEGRAM_TOKEN_HERE/getUpdates
+  3. Send /start to your bot and open https://api.telegram.org/bot{$TELEGRAM_TOKEN_HERE}/getUpdates
   4. Take chat_id from response
 Require telegram recipe in your `deploy.php` file:
 
@@ -20,6 +20,7 @@ before('deploy', 'telegram:notify');
 ## Configuration
 
 - `telegram_token` – telegram bot token, **required** 
+- `telegram_chat_id` — chat ID to push messages to
 - `telegram_title` – the title of application, default `{{application}}`
 - `telegram_text` – notification message template
   ```
@@ -48,3 +49,4 @@ If you want to notify about successful end of deployment add this too:
 ```php
 after('success', 'telegram:notify:success');
 ```
+

--- a/recipe/telegram.php
+++ b/recipe/telegram.php
@@ -3,10 +3,10 @@
  * Based on Slack nofifier recipe by Anton Medvedev
  * Configuration:
     1. Create telegram bot by any manual in the internet
-    2. Take telegrambot token (Like: 123456789:SOME_STRING) and set $TELEGRAM_TOKEN_HERE
-    3. Send /start to your bot, open https://api.telegram.org/bot$TELEGRAM_TOKEN_HERE/getUpdates
-    4. Take chat_id from response, it will be $TELEGRAM_CHATID_HERE
-    5. If you want, you can edit telegram_text and telegram_success_text
+    2. Take telegrambot token (Like: 123456789:SOME_STRING) and set `telegram_token` parameter
+    3. Send /start to your bot, open https://api.telegram.org/bot{telegram_token}/getUpdates
+    4. Take chat_id from response, and set `telegram_chat_id` parameter
+    5. If you want, you can edit `telegram_text` and `telegram_success_text`
     6. Profit!
  */
 namespace Deployer;

--- a/recipe/telegram.php
+++ b/recipe/telegram.php
@@ -18,11 +18,15 @@ set('telegram_title', function () {
 });
 
 // Telegram settings
-    set('telegram_token', $TELEGRAM_TOKEN_HERE);
-    set('telegram_chat_id', $TELEGRAM_CHATID_HERE);
-    set('telegram_url', function () {
-       return 'https://api.telegram.org/bot' . get('telegram_token') . '/sendmessage';
-    });
+set('telegram_token', function () {
+    throw new \Exception('Please, configure "telegram_token" parameter.');
+});
+set('telegram_chat_id', function () {
+    throw new \Exception('Please, configure "telegram_chat_id" parameter.');
+});
+set('telegram_url', function () {
+   return 'https://api.telegram.org/bot' . get('telegram_token') . '/sendmessage';
+});
 
 // Deploy message
 set('telegram_text', '_{{user}}_ deploying `{{branch}}` to *{{target}}*');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #170 

Thanks for deployer, it saves me lots of time!

Fixed telegram recipe, that used undefined variables (probably left from demo). Also added `telegram_chat_id` parameter to docs.

If one of  `telegram_token` or `telegram_chat_id` is unset, the `\Exception` is thrown (based on other recipes).

Last thing is that I added link to telegram recipe doc to README.