### PR TITLE
Typo in slack recipe (temp) path

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -14,7 +14,7 @@ Require slack recipe in your `deploy.php` file:
 
 ```php
 //require 'recipe/slack.php';
-require 'vendor/deployer/recipe/recipes/slack.php';
+require 'vendor/deployer/recipes/recipe/slack.php';
 ```
 
 Add hook on deploy:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I know the require path was replaced in the doc as a temp fix, but I imagine it'd be better to give the proper path anyway :)
