### PR TITLE
Fix for discord recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed telegram recipe (#170) and updated docs
 - Fixed newrelic recipe
+- Fixed discord recipe (#181) and updated docs
 
 ## 6.0.2
 [6.0.1...6.0.2](https://github.com/deployphp/recipes/compare/6.0.1...6.0.2)

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -20,22 +20,16 @@ before('deploy', 'discord:notify');
 - `discord_token` – Discord channel token, **required**
 
 - `discord_notify_text` – notification message template, markdown supported, default:
-  ```php
-  [
-      'text' => ':information_source: **{{user}}** is deploying branch `{{branch}}` to _{{target}}_',
-  ]
+  ```markdown
+  :information_source: **{{user}}** is deploying branch `{{branch}}` to _{{target}}_
   ```
 - `discord_success_text` – success template, default:
-  ```php
-  [
-      'text' => ':white_check_mark: Branch `{{branch}}` deployed to _{{target}}_ successfully',
-  ]
+  ```markdown
+  :white_check_mark: Branch `{{branch}}` deployed to _{{target}}_ successfully
   ```
 - `discord_failure_text` – failure template, default:
-  ```php
-  [
-      'text' => ':no_entry_sign: Branch `{{branch}}` has failed to deploy to _{{target}}_',
-  ]
+  ```markdown
+  :no_entry_sign: Branch `{{branch}}` has failed to deploy to _{{target}}_
 
 ## Tasks
 

--- a/recipe/discord.php
+++ b/recipe/discord.php
@@ -9,38 +9,35 @@ set('discord_webhook', function () {
 });
 
 // Deploy messages
-set('discord_notify_text', [
-    'text' => ':information_source: **{{user}}** is deploying branch `{{branch}}` to _{{target}}_',
-]);
-set('discord_success_text', [
-    'text' => ':white_check_mark: Branch `{{branch}}` deployed to _{{target}}_ successfully',
-]);
-set('discord_failure_text', [
-    'text' => ':no_entry_sign: Branch `{{branch}}` has failed to deploy to _{{target}}_',
-]);
+set('discord_notify_text', ':information_source: **{{user}}** is deploying branch `{{branch}}` to _{{target}}_');
+set('discord_success_text', ':white_check_mark: Branch `{{branch}}` deployed to _{{target}}_ successfully');
+set('discord_failure_text', ':no_entry_sign: Branch `{{branch}}` has failed to deploy to _{{target}}_');
+
+// The message
+set('discord_message', 'discord_notify_text');
 
 // Helpers
-set('send_message', function ($data) {
-    Httpie::post(get('discord_webhook'))->body($data)->send();
+task('discord_send_message', function(){
+    Httpie::post(get('discord_webhook'))->body(['text' => get(get('discord_message'))])->send();
 });
 
 // Tasks
 desc('Just notify your Discord channel with all messages, without deploying');
 task('discord:test', function () {
-    $notify = get('discord_notify_text');
-    $success = get('discord_success_text');
-    $failure = get('discord_failure_text');
-
-    get('send_message')($notify);
-    get('send_message')($success);
-    get('send_message')($failure);
+    set('discord_message', 'discord_notify_text');
+    invoke('discord_send_message');
+    set('discord_message', 'discord_success_text');
+    invoke('discord_send_message');
+    set('discord_message', 'discord_failure_text');
+    invoke('discord_send_message');
 })
     ->once()
     ->shallow();
 
 desc('Notify Discord');
 task('discord:notify', function () {
-    get('send_message')(get('discord_notify_text'));
+    set('discord_message', 'discord_notify_text');
+    invoke('discord_send_message');
 })
     ->once()
     ->shallow()
@@ -48,7 +45,8 @@ task('discord:notify', function () {
 
 desc('Notify Discord about deploy finish');
 task('discord:notify:success', function () {
-    get('send_message')(get('discord_success_text'));
+    set('discord_message', 'discord_success_text');
+    invoke('discord_send_message');
 })
     ->once()
     ->shallow()
@@ -56,7 +54,8 @@ task('discord:notify:success', function () {
 
 desc('Notify Discord about deploy failure');
 task('discord:notify:failure', function () {
-    get('send_message')(get('discord_failure_text'));
+    set('discord_message', 'discord_failure_text');
+    invoke('discord_send_message');
 })
     ->once()
     ->shallow()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #181 

This pr fixes ticket #181
 
------

I also tried to make it possible to set `discord_message` directly.
```php
// Helpers
task('discord_send_message', function(){
    $message = get('discord_message');
    if(has($message)){
        $message = get($message);
    }
    Httpie::post(get('discord_webhook'))->body(['text' => $message])->send();
});
```
But I can't check it with `has`, it always returns `false`. After debugging I also saw that the context configuration only contains the host information and the key `discord_message`, the others are stored in the `Deployer` instance configuration. I'm ready to provide a pr if I get any solution.
