### PR TITLE
Allow messages to be complex on Discord recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Fixed
+- Fixed sending complex messages to discord
+
 ## master
 [6.0.2...master](https://github.com/deployphp/recipes/compare/6.0.2...master)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-### Fixed
-- Fixed sending complex messages to discord
-
 ## master
 [6.0.2...master](https://github.com/deployphp/recipes/compare/6.0.2...master)
 
@@ -12,10 +9,10 @@
 - Added Google Hangouts Chat recipe, based on Slack recipe.
 
 ### Fixed
-
 - Fixed telegram recipe (#170) and updated docs
 - Fixed newrelic recipe
 - Fixed discord recipe (#181) and updated docs
+- Fixed sending complex messages to discord
 
 ## 6.0.2
 [6.0.1...6.0.2](https://github.com/deployphp/recipes/compare/6.0.1...6.0.2)
@@ -34,5 +31,4 @@
 [6.0.0...6.0.1](https://github.com/deployphp/recipes/compare/6.0.0...6.0.1)
 
 ### Fixed
-
 - Fixed bug with test func in rsync recipe

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains third party recipes to integrate with deployer.
 ## Installing
 
 ~~~sh
-composer require deployer/recipes --dev 
+composer require deployer/recipes --dev
 ~~~
 
 Include recipes in `deploy.php` file.
@@ -18,24 +18,25 @@ require 'recipe/slack.php';
 
 ## Recipes
 
-| Recipe     | Docs                      
-| ------     | ----                      
-| bugsnag    | [read](docs/bugsnag.md)   
-| cachetool  | [read](docs/cachetool.md) 
+| Recipe     | Docs
+| ------     | ----
+| bugsnag    | [read](docs/bugsnag.md)
+| cachetool  | [read](docs/cachetool.md)
 | cloudflare | [read](docs/cloudflare.md)
-| hipchat    | [read](docs/hipchat.md)   
-| newrelic   | [read](docs/newrelic.md)  
-| npm        | [read](docs/npm.md)       
-| phinx      | [read](docs/phinx.md)     
-| rabbit     | [read](docs/rabbit.md)    
-| rollbar    | [read](docs/rollbar.md)   
-| rsync      | [read](docs/rsync.md)     
-| sentry     | [read](docs/sentry.md)    
-| slack      | [read](docs/slack.md)     
+| discord    | [read](docs/discord.md)
+| hipchat    | [read](docs/hipchat.md)
+| newrelic   | [read](docs/newrelic.md)
+| npm        | [read](docs/npm.md)
+| phinx      | [read](docs/phinx.md)
+| rabbit     | [read](docs/rabbit.md)
+| rollbar    | [read](docs/rollbar.md)
+| rsync      | [read](docs/rsync.md)
+| sentry     | [read](docs/sentry.md)
+| slack      | [read](docs/slack.md)
 | telegram   | [read](docs/telegram.md)
 | yammer     | [read](docs/yammer.md)
-| yarn       | [read](docs/yarn.md)      
-| raygun     | [read](docs/raygun.md)      
+| yarn       | [read](docs/yarn.md)
+| raygun     | [read](docs/raygun.md)
 
 
 ## Contributing

--- a/recipe/discord.php
+++ b/recipe/discord.php
@@ -9,16 +9,24 @@ set('discord_webhook', function () {
 });
 
 // Deploy messages
-set('discord_notify_text', ':information_source: **{{user}}** is deploying branch `{{branch}}` to _{{target}}_');
-set('discord_success_text', ':white_check_mark: Branch `{{branch}}` deployed to _{{target}}_ successfully');
-set('discord_failure_text', ':no_entry_sign: Branch `{{branch}}` has failed to deploy to _{{target}}_');
+set('discord_notify_text', [
+    'text' => ':information_source: **{{user}}** is deploying branch `{{branch}}` to _{{target}}_',
+]);
+set('discord_success_text', [
+    'text' => ':white_check_mark: Branch `{{branch}}` deployed to _{{target}}_ successfully',
+]);
+set('discord_failure_text', [
+    'text' => ':no_entry_sign: Branch `{{branch}}` has failed to deploy to _{{target}}_',
+]);
 
 // The message
 set('discord_message', 'discord_notify_text');
 
 // Helpers
 task('discord_send_message', function(){
-    Httpie::post(get('discord_webhook'))->body(['text' => get(get('discord_message'))])->send();
+    $message = get(get('discord_message'));
+
+    Httpie::post(get('discord_webhook'))->body($message)->send();
 });
 
 // Tasks


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/recipes/blob/master/CHANGELOG.md)

--------------

Hey @chapterjason thanks a lot for your previous fix, but it ended up to unable user to send 'complex' messages, just like this:
```php
set('discord_notify_text', function () {
    return [
        'attachments' => [
            [
                'title' => get('application') . ' Application Has Started Deploying...',
                'fields' => [
                    [
                        'title' => 'Environment',
                        'value' => get('stage'),
                        'short' => true
                    ],
                    [
                        'title' => 'Branch',
                        'value' => get('branch') ?: 'master',
                        'short' => true
                    ],
                    [
                        'title' => 'Deployer',
                        'value' => get('user'),
                        'short' => true
                    ],
                ],
            ],
        ],
    ];
});
```

Because you set every single message as `text`. So I'm writing this PR just to get back to default messages with the `text` index in case user don't want to send complex messages. 🙂

@antonmedv let me know if you agree with this. Thank you guys!