### PR TITLE
Use configuration for New Relic revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added grafana recipe.
 - Added yammer recipe, based on Slack recipe.
 - Added Google Hangouts Chat recipe, based on Slack recipe.
+- Added support for New Relic deployment revision as config.
 
 ### Fixed
 - Fixed telegram recipe (#170) and updated docs

--- a/recipe/newrelic.php
+++ b/recipe/newrelic.php
@@ -17,6 +17,10 @@ set('newrelic_description', function() {
     return runLocally('git log -n 1 --format="%an: %s" | tr \'"\' "\'"');
 });
 
+set('newrelic_revision', function() {
+    return runLocally('git log -n 1 --format="%h"');
+});
+
 desc('Notifying New Relic of deployment');
 task('newrelic:notify', function () {
     $appId = get('newrelic_app_id');
@@ -24,7 +28,7 @@ task('newrelic:notify', function () {
 
     $data = [
         'user' => get('user'),
-        'revision' => runLocally('git log -n 1 --format="%h"'),
+        'revision' => get('newrelic_revision'),
         'description' => get('newrelic_description'),
     ];
 


### PR DESCRIPTION
This allows you to override revision retrieval for custom builds. This
is useful for builds where the revision is not in the current
directory.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A