### PR TITLE
Cannot use --web option

### DIFF
--- a/recipe/cachetool.php
+++ b/recipe/cachetool.php
@@ -16,8 +16,11 @@ desc('Clearing APC system cache');
 task('cachetool:clear:apc', function () {
     $releasePath = get('release_path');
     $options = get('cachetool');
+    $fullOptions = get('cachetool_args');
 
-    if (strlen($options)) {
+    if (strlen($fullOptions) > 0) {
+        $options = "{$fullOptions}";
+    } elseif (strlen($options) > 0) {
         $options = "--fcgi={$options}";
     }
 
@@ -38,8 +41,11 @@ desc('Clearing OPcode cache');
 task('cachetool:clear:opcache', function () {
     $releasePath = get('release_path');
     $options = get('cachetool');
+    $fullOptions = get('cachetool_args');
 
-    if (strlen($options)) {
+    if (strlen($fullOptions) > 0) {
+        $options = "{$fullOptions}";
+    } elseif (strlen($options) > 0) {
         $options = "--fcgi={$options}";
     }
 


### PR DESCRIPTION
The cachetool has a --web option. However, this cannot be used because --fcgi= is always prefixed in front of the options.

Adding cachetool_args allows you to customise all arguments.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/recipes/blob/master/CHANGELOG.md)
