### PR TITLE
[Sentry] Added content type headers to sentry requests

### DIFF
--- a/recipe/sentry.php
+++ b/recipe/sentry.php
@@ -82,6 +82,7 @@ EXAMPLE
             $releasesApiUrl
         )
             ->header(sprintf('Authorization: Bearer %s', $config['token']))
+            ->header('Content-Type: application/json')
             ->body($releaseData)
             ->getJson();
 
@@ -112,6 +113,7 @@ EXAMPLE
             $releasesApiUrl . $response['version'] . '/deploys/'
         )
             ->header(sprintf('Authorization: Bearer %s', $config['token']))
+            ->header('Content-Type: application/json')
             ->body($deployData)
             ->getJson();
 


### PR DESCRIPTION
Sentry requires the content-type headers to accept certain api requests. I've added these headers to both requests.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/recipes/blob/master/CHANGELOG.md)

Already covert in the previous recipe message
