### PR TITLE
Add npm:ci (clean install) command to npm recipe

### DIFF
--- a/docs/npm.md
+++ b/docs/npm.md
@@ -21,9 +21,15 @@ require 'recipe/npm.php';
 ## Tasks
 
 - `npm:install` – install npm packages
+- `npm:ci` – install npm packages with a new and "clean" node_modules directory
 
 ## Usage
 
 ~~~php
 after('deploy:update_code', 'npm:install');
+~~~
+
+or if you want use `npm ci` command
+~~~php
+after('deploy:update_code', 'npm:ci');
 ~~~

--- a/recipe/npm.php
+++ b/recipe/npm.php
@@ -20,3 +20,9 @@ task('npm:install', function () {
     }
     run("cd {{release_path}} && {{bin/npm}} install");
 });
+
+
+desc('Install npm packages with a clean slate');
+task('npm:ci', function () {
+    run("cd {{release_path}} && {{bin/npm}} ci");
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

As the documentation said (https://docs.npmjs.com/cli/ci.html) we should use npm ci install of npm install during deployments

> This command is similar to npm-install, except it’s meant to be used in automated environments such as test platforms, continuous integration, and deployment – or any situation where you want to make sure you’re doing a clean install of your dependencies. It can be significantly faster than a regular npm install by skipping certain user-oriented features. It is also more strict than a regular install, which can help catch errors or inconsistencies caused by the incrementally-installed local environments of most npm users.