### PR TITLE
Slack > Success message green

### DIFF
--- a/recipe/slack.php
+++ b/recipe/slack.php
@@ -21,7 +21,7 @@ set('slack_failure_text', 'Deploy to *{{target}}* failed');
 
 // Color of attachment
 set('slack_color', '#4d91f7');
-set('slack_success_color', '{{slack_color}}');
+set('slack_success_color', '#00c100');
 set('slack_failure_color', '#ff0909');
 
 desc('Notifying Slack');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

As the failure message has the red color I think that makes sense to have a green notification in a success case.
