### PR TITLE
Fix Sentry "Unsupported media type 'application/json, application/json' in request"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Add APCu support in cachetool recipe
+- Fixed Sentry deployment recipe, updated to work with latest deployer/deployer
 
 ## 6.2.0
 [6.1.0...6.2.0](https://github.com/deployphp/recipes/compare/6.1.0...6.2.0)

--- a/recipe/sentry.php
+++ b/recipe/sentry.php
@@ -82,7 +82,6 @@ EXAMPLE
             $releasesApiUrl
         )
             ->header(sprintf('Authorization: Bearer %s', $config['token']))
-            ->header('Content-Type: application/json')
             ->body($releaseData)
             ->getJson();
 
@@ -113,7 +112,6 @@ EXAMPLE
             $releasesApiUrl . $response['version'] . '/deploys/'
         )
             ->header(sprintf('Authorization: Bearer %s', $config['token']))
-            ->header('Content-Type: application/json')
             ->body($deployData)
             ->getJson();
 


### PR DESCRIPTION
The header is already set by called Httpie library. Calling ::header just adds a new header, does not do any replace: https://github.com/deployphp/deployer/blame/master/src/Utility/Httpie.php#L58-L67

Sentry does not recognize the request when we send the headers twice and fails with error:
```
  [RuntimeException] on [factcool-www3.superhosting.cz]
  Unable to create a release: Array
  (
  [detail] => Unsupported media type 'application/json, application/json' in request.
  )
```

This merge requests fixed the issue.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A


