### PR TITLE
Add optional version prefix to Sentry recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add APCu support in cachetool recipe
 - Fixed Sentry deployment recipe, updated to work with latest deployer/deployer
 - Added check in NPM recipe to check if `package.json` has changed before running `npm install`
+- Added optional version prefix to Sentry recipe
 
 ## 6.2.0
 [6.1.0...6.2.0](https://github.com/deployphp/recipes/compare/6.1.0...6.2.0)

--- a/docs/sentry.md
+++ b/docs/sentry.md
@@ -15,6 +15,8 @@ require 'recipe/sentry.php';
 - **token** *(required)*: authentication token. Can be created at [https://sentry.io/settings/account/api/auth-tokens/]
 - **version** *(required)* – a version identifier for this release. 
 Can be a version number, a commit hash etc. (Defaults is set to git log -n 1 --format="%h".)
+- **version_prefix** *(optional)* - a string prefixed to version.
+Releases are global per organization so indipentent projects needs to prefix version number with unique string to avoid conflicts
 - **environment** *(optional)* - the environment you’re deploying to. By default framework's environment is used. 
 For example for symfony, *symfony_env* configuration is read otherwise defaults to 'prod'.
 - **ref** *(optional)* – an optional commit reference. This is useful if a tagged version has been provided.

--- a/recipe/sentry.php
+++ b/recipe/sentry.php
@@ -19,6 +19,7 @@ task(
 
         $defaultConfig = [
             'version' => null,
+            'version_prefix' => null,
             'refs' => [],
             'ref' => null,
             'commits' => null,
@@ -71,7 +72,7 @@ EXAMPLE
 
         $releaseData = array_filter(
             [
-                'version' => $config['version'],
+                'version' => ($config['version_prefix'] ?? '') . $config['version'],
                 'refs' => $config['refs'],
                 'ref' => $config['ref'],
                 'url' => $config['url'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

On Sentry.io releases are global per organization, so indipendent projects in same organization must use a prefix to version numbers to avoid conflicts (see https://docs.sentry.io/workflow/releases/?platform=php#configure-sdk)
