### PR TITLE
Fix a default message in the Rabbit recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Added check in NPM recipe to check if `package.json` has changed before running `npm install`
 - Added optional version prefix to Sentry recipe
 
+### Fixed
+- Fixed rabbit recipe (#244)
+
 ## 6.2.0
 [6.1.0...6.2.0](https://github.com/deployphp/recipes/compare/6.1.0...6.2.0)
 

--- a/recipe/rabbit.php
+++ b/recipe/rabbit.php
@@ -24,8 +24,17 @@ task('deploy:rabbit', function () {
     if (!isset($config['message'])) {
         $releasePath = get('release_path');
         $host = Context::get()->getHost();
-        $prod = get('env', 'production');
-        $config['message'] = "Deployment to '{$host}' on *{$prod}* was successful\n($releasePath)";
+
+        $stage = get('stage', false);
+        $stageInfo = ($stage) ? sprintf(' on *%s*', $stage) : '';
+
+        $message = "Deployment to '%s'%s was successful\n(%s)";
+        $config['message'] = sprintf(
+            $message,
+            $host,
+            $stageInfo,
+            $releasePath
+        );
     }
 
     $defaultConfig = array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

The `'env'` configuration parameter is supposed to be an array of environment variables, but this recipe treats it like a string, so PHP throws an "Array to string conversion" notice and the message in the queue becomes muddy:
`Deployment to 'localhost' on *Array* was successful`

This patch instead makes use of the stage information (if available):
`Deployment to 'localhost' on *production* was successful`
`Deployment to 'localhost' was successful`
