### PR TITLE
[Yarn] If package.json is unmodified, then skip running `yarn install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added workplace recipe, based on rocketchat recipe
 - Add APCu support in cachetool recipe
 - Fixed Sentry deployment recipe, updated to work with latest deployer/deployer
-- Added check in NPM recipe to check if `package.json` has changed before running `npm install`
+- Added check in NPM and Yarn recipes to check if `package.json` has changed before running `npm install`/`yarn install`
 - Added optional version prefix to Sentry recipe
 
 ### Fixed

--- a/recipe/yarn.php
+++ b/recipe/yarn.php
@@ -17,6 +17,11 @@ task('yarn:install', function () {
     if (has('previous_release')) {
         if (test('[ -d {{previous_release}}/node_modules ]')) {
             run('cp -R {{previous_release}}/node_modules {{release_path}}');
+
+            // If package.json is unmodified, then skip running `yarn install`
+            if (!run('diff {{previous_release}}/package.json {{release_path}}/package.json')) {
+                return;
+            }
         }
     }
     run("cd {{release_path}} && {{bin/yarn}}");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This is the same feature as [this one](https://github.com/deployphp/recipes/pull/237), but for Yarn.
