### PR TITLE
Fix Exit Code: 128 in sentry recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Fixed rabbit recipe (#244)
+- Fixed sentry releases, if git does not exist
 
 ## 6.2.0
 [6.1.0...6.2.0](https://github.com/deployphp/recipes/compare/6.1.0...6.2.0)

--- a/recipe/sentry.php
+++ b/recipe/sentry.php
@@ -138,7 +138,7 @@ EXAMPLE
 
 function releaseIsGitDirectory()
 {
-    return (bool) run('cd {{release_path}} && git rev-parse --git-dir > /dev/null 2>&1 && echo 1');
+    return (bool) run('cd {{release_path}} && git rev-parse --git-dir > /dev/null 2>&1 && echo 1 || echo 0');
 }
 
 function getReleaseGitRef(): Closure


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

![Screenshot from 2020-02-05 15-27-00](https://user-images.githubusercontent.com/646054/73846107-a0196080-482c-11ea-8931-f1eefdd0983f.png)

Ater fix, 
```
git rev-parse --git-dir > /dev/null 2>&1 && echo 1 || echo 0
```
return 0 if git does not exist, and return 1, if all good

Line git rev-parse --git-dir > /dev/null 2>&1 && echo 1 return code 128, if git does not exist
```
# git rev-parse --git-dir > /dev/null 2>&1 && echo 1
# $?
bash: 128: command not found
```
But symfony process return exception, if code it is not a zero
https://github.com/symfony/process/blob/7075b84559f3624c9f1fcde37c5af7a3e025ec8a/Process.php#L251