### PR TITLE
Fix small typo documentation

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -4,6 +4,7 @@
   1. Create telegram bot with [BotFather](https://t.me/BotFather) and grab the token provided
   2. Send `/start` to your bot and open https://api.telegram.org/bot{$TELEGRAM_TOKEN_HERE}/getUpdates
   3. Take chat_id from response
+  
 Require telegram recipe in your `deploy.php` file:
 
 ```php


### PR DESCRIPTION
On github the readme was not clear, now the other sentence goes to a new line

| Q             | A
| ------------- | ---
| Bug fix?      | No, it is a typo 
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 
