### PR TITLE
Cachetool fix for 4.X family and PHP version 7.1.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Fixed
+
+- Adding the ability to pick a release from the 4.X cachetool family, which works with PHP >=7.1
 
 ## master
 [6.2.0...master](https://github.com/deployphp/recipes/compare/6.2.0...master)

--- a/recipe/cachetool.php
+++ b/recipe/cachetool.php
@@ -10,7 +10,7 @@ namespace Deployer;
 set('cachetool', '');
 set('cachetool_args', '');
 set('cachetool_binary', function () {
-    return run("{{bin/php}} -r \"echo version_compare(phpversion(), '7.1') == -1 ? 'cachetool-3.2.1.phar' : 'cachetool.phar';\"");
+    return run("{{bin/php}} -r \"echo (PHP_VERSION_ID <= 50640) ? 'cachetool-3.2.1.phar' : ((PHP_VERSION_ID <= 70133) ? 'cachetool-4.1.1.phar' : 'cachetool.phar');\"");
 });
 set('bin/cachetool', function () {
     $cachetool_binary = get('cachetool_binary');


### PR DESCRIPTION
After the release of the **5.X** family of cachetool, `cachetool.phar` no longer refers to a member of 4.X family, but to the last tag of the new family instead. This introduces an error when **cachetool** is executed from an environment with PHP 7.1.X, as the new `cachetool.phar` works with PHP >=7.2.

E.g.

```
$ php71 /var/www/[...]/cachetool.phar --version
PHP Fatal error:  Uncaught Error: Call to undefined function Symfony\Component\Console\Output\stream_isatty() in phar:///var/www/[...]/cachetool.phar/vendor/symfony/console/Output/StreamOutput.php:117
Stack trace:
#0 phar:///var/www/[...]/cachetool.phar/vendor/symfony/console/Output/StreamOutput.php(52): Symfony\Component\Console\Output\StreamOutput->hasColorSupport()
#1 phar:///var/www/[...]/cachetool.phar/vendor/symfony/console/Output/ConsoleOutput.php(42): Symfony\Component\Console\Output\StreamOutput->__construct(Resource id #71, 32, NULL, NULL)
#2 phar:///var/www/[...]/cachetool.phar/vendor/symfony/console/Application.php(118): Symfony\Component\Console\Output\ConsoleOutput->__construct()
#3 phar:///var/www/[...]/ in phar:///var/www/[...]/cachetool.phar/vendor/symfony/console/Output/StreamOutput.php on line 117
```
So, at this point we have 3 (or more), not 2, possible paths:
1. **CacheTool 3.x** which works with PHP >=5.5.9
2. **CacheTool 4.x** works with PHP >=7.1
3. **CacheTool 5.x** works with PHP >=7.2 (referred to in the recipe as `cachetool.phar`)

##### MODIFICATIONS:

- Fixed cachetool recipe by adding the ability to pick a release from the 4.X family which is now intended for PHP >=7.1

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A
