### PR TITLE
Remove private mode from Rollbar recipe.

### DIFF
--- a/recipe/rollbar.php
+++ b/recipe/rollbar.php
@@ -31,5 +31,4 @@ task('rollbar:notify', function () {
         ->send();
 })
     ->once()
-    ->shallow()
-    ->setPrivate();
+    ->shallow();


### PR DESCRIPTION
The Rollbar notify command should be publicly accessible, otherwise an error like `There are no commands defined in the "rollbar" namespace.` gets thrown.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    |  No
| Deprecations? | No
| Fixed tickets | N/A
